### PR TITLE
fix(Animation): Use default element positioning for the animation container

### DIFF
--- a/styles/animation/_container.scss
+++ b/styles/animation/_container.scss
@@ -1,8 +1,5 @@
 @include exports('animation/container') {
 .animation-container {
-    height: 100%;
     overflow: hidden;
-    position: relative;
-    white-space: nowrap;
 }
 }


### PR DESCRIPTION
The change is required for the **popup** element positioning and more specifically for the calculation of the animation container position.

Before that, the animation container was with `position: relative`, which changes the offset parent and hence the calculation of the element position and offset.
