### PR TITLE
refactor(popup): make animation-container absolute positioned

### DIFF
--- a/styles/animation/_container.scss
+++ b/styles/animation/_container.scss
@@ -2,5 +2,6 @@
 .k-animation-container {
     position: absolute;
     overflow: hidden;
+    z-index: 100;
 }
 }

--- a/styles/animation/_container.scss
+++ b/styles/animation/_container.scss
@@ -1,5 +1,6 @@
 @include exports('animation/container') {
 .k-animation-container {
+    position: absolute;
     overflow: hidden;
 }
 }

--- a/styles/popup/_layout.scss
+++ b/styles/popup/_layout.scss
@@ -1,6 +1,5 @@
 @include exports('popup/layout') {
 .k-popup {
-    position: absolute;
     z-index: 100;
 
     .k-list-container,

--- a/styles/popup/_layout.scss
+++ b/styles/popup/_layout.scss
@@ -1,7 +1,5 @@
 @include exports('popup/layout') {
 .k-popup {
-    z-index: 100;
-
     .k-list-container,
     .k-calendar-container {
         -webkit-touch-callout: none;


### PR DESCRIPTION
The k-popup class was moved to the animation-container content, hence it shouldn't be absolute positioned anymore.
