### PR TITLE
feat: content in panelbar headers should not be selectable

### DIFF
--- a/styles/panelbar/_theme.scss
+++ b/styles/panelbar/_theme.scss
@@ -28,6 +28,10 @@ $panelbar-selected-focused-hover-box-shadow: inset 0 0 0 2px blend-multiply($acc
     }
 
     .k-item {
+        > .k-header {
+            user-select: none;
+        }
+
         .k-link {
             color: $panelbar-color;
             transition: $transition;


### PR DESCRIPTION
Content in PanelBar headers should not be selectable. telerik/kendo-theme-default#25
