### PR TITLE
chore: fix lint warning messages

### DIFF
--- a/styles/base/_layout.scss
+++ b/styles/base/_layout.scss
@@ -67,9 +67,11 @@ html {
         stroke-dasharray: 0 251;
         stroke-dashoffset: 502;
     }
+
     50% {
         stroke-dasharray: 250 1;
     }
+
     100% {
         stroke-dasharray: 0 251;
         stroke-dashoffset: 0;


### PR DESCRIPTION
Fix lint warning messages - _"Space expected between blocks"_
