### PR TITLE
feat: add default font-size to .k-widget

### DIFF
--- a/styles/base/_layout.scss
+++ b/styles/base/_layout.scss
@@ -13,6 +13,11 @@ html {
     text-decoration: none;
 }
 
+.k-widget {
+    font-size: 14px;
+    font-family: inherit;
+}
+
 .k-textbox > input,
 .k-input,
 .k-textbox,


### PR DESCRIPTION
Add default font-size 14px to .k-widget. Related to [https://github.com/telerik/kendo-theme-default/issues/33](url)
