### PR TITLE
fix: chart default font-size; major/minor gridlines colors

### DIFF
--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -23,3 +23,6 @@ $series-c: #78d237 !default;
 $series-d: #28b4c8 !default;
 $series-e: #2d73f5 !default;
 $series-f: #aa46be !default;
+
+$base-font-size: 14px !default;
+$base-font-family: inherit !default;

--- a/styles/base/_layout.scss
+++ b/styles/base/_layout.scss
@@ -14,8 +14,8 @@ html {
 }
 
 .k-widget {
-    font-size: 14px;
-    font-family: inherit;
+    font-size: $base-font-size;
+    font-family: $base-font-family;
 }
 
 .k-textbox > input,

--- a/styles/charts/_layout.scss
+++ b/styles/charts/_layout.scss
@@ -3,7 +3,7 @@
 $chart-tap-highlight-color: rgba(0, 0, 0, 0);
 $chart-selection-background: rgba(255, 255, 255, .01);
 
-$chart-font-size: 14px !default;
+$chart-font-size: $base-font-size !default;
 $chart-tooltip-font-size: .929em !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
@@ -29,7 +29,7 @@ $chart-title-font-size: 1.143em !default;
     .k-chart,
     .k-stockchart {
         font-size: $chart-font-size;
-        font-family: inherit;
+        font-family: $base-font-family;
         display: block;
         height: 400px;
     }

--- a/styles/charts/_layout.scss
+++ b/styles/charts/_layout.scss
@@ -3,12 +3,22 @@
 $chart-tap-highlight-color: rgba(0, 0, 0, 0);
 $chart-selection-background: rgba(255, 255, 255, .01);
 
-$chart-font-size: 1em !default;
+$chart-font-size: 14px !default;
 $chart-tooltip-font-size: .929em !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
 
 @include exports('charts/layout') {
+    // Exported variables
+    .k-var--chart-title-font {
+        font-size: $chart-title-font-size;
+    }
+
+    .k-var--chart-label-font {
+        font-size: $chart-label-font-size;
+    }
+
+    // Elements
     .k-chart,
     .k-sparkline,
     .k-stockchart {
@@ -18,6 +28,8 @@ $chart-title-font-size: 1.143em !default;
 
     .k-chart,
     .k-stockchart {
+        font-size: $chart-font-size;
+        font-family: inherit;
         display: block;
         height: 400px;
     }

--- a/styles/charts/_theme.scss
+++ b/styles/charts/_theme.scss
@@ -3,8 +3,8 @@
 @import './layout';
 
 $chart-inactive: $disabled-border-color !default;
-$chart-major-lines: darken($base, 30%) !default;
-$chart-minor-lines: darken($base, 20%) !default;
+$chart-major-lines: rgba(0, 0, 0, .08) !default;
+$chart-minor-lines: rgba(0, 0, 0, .08) !default;
 
 $chart-font-size-s: 11px !default;
 $chart-font-size-m: 12px !default;


### PR DESCRIPTION
Change chart default font-size to 14px. Change major / minor gridlens colors to match the design
