### PR TITLE
fix: add var for chart default font size

### DIFF
--- a/styles/charts/_layout.scss
+++ b/styles/charts/_layout.scss
@@ -10,6 +10,10 @@ $chart-title-font-size: 1.143em !default;
 
 @include exports('charts/layout') {
     // Exported variables
+    .k-var--chart-font {
+        font-size: $chart-font-size;
+    }
+
     .k-var--chart-title-font {
         font-size: $chart-title-font-size;
     }


### PR DESCRIPTION
Add a variable for chart default font size
