### PR TITLE
fix: incorrect padding of k-tabstrip-items

### DIFF
--- a/styles/tabstrip/_layout.scss
+++ b/styles/tabstrip/_layout.scss
@@ -26,8 +26,6 @@
 }
 
 .k-tabstrip-items {
-    padding: .3em .3em 0;
-
     .k-tabstrip-scrollable & {
         overflow: hidden;
         white-space: nowrap;


### PR DESCRIPTION
Fix incorrect padding of k-tabstrip-items. Related to issue #47 