### PR TITLE
fix: add text alignment to droplowns

### DIFF
--- a/styles/dropdowns/_layout.scss
+++ b/styles/dropdowns/_layout.scss
@@ -17,6 +17,7 @@ $input-indent: .33em;
     overflow: visible;
     border-width: 0;
     vertical-align: middle;
+    text-align: left;
 }
 
 .k-autocomplete,


### PR DESCRIPTION
closes telerik/kendo-angular-dropdowns#75