### PR TITLE
fix: use content-box sizing on popup element

### DIFF
--- a/scss/popup/_layout.scss
+++ b/scss/popup/_layout.scss
@@ -7,7 +7,7 @@
         border-style: solid;
         font-size: $font-size;
         line-height: $line-height;
-        box-sizing: border-box;
+        box-sizing: content-box;
 
         .k-item {
             cursor: pointer;


### PR DESCRIPTION
Can be tested on basic usage demo on ng2 staging.

Not sure why we use the box-sizing in the first place, but it seems that the popup does not handle it well.