### PR TITLE
chore(maskedtextbox): styles for maskedtextbox

### DIFF
--- a/scss/common/_forms.scss
+++ b/scss/common/_forms.scss
@@ -70,8 +70,8 @@
         .k-input {
             padding: $input-padding-y $input-padding-x;
             width: 100%;
-            height: $line-height-em;
-            box-sizing: content-box;
+            height: calc( #{$line-height-em} + #{$input-padding-y * 2});
+            box-sizing: border-box;
             border: 0;
             outline: 0;
             color: inherit;

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -5,38 +5,47 @@
     $textbox-shadow: 0 2px 2px 1px rgba(0, 0, 0, .06) !default;
     $fieldset-margin: 30px;
 
-    .k-textbox > input,
-    .k-input,
-    .k-textbox {
+    .k-textbox,
+    .k-maskedtextbox {
+        @include border-radius( $border-radius );
+        padding: $input-padding-y $input-padding-x;
+        width: 12.4em;
+        box-sizing: border-box;
         border-width: 1px;
         border-style: solid;
-        font-size: inherit;
+        outline: 0;
+        font: inherit;
+        line-height: $form-line-height;
+        display: inline-flex;
+        vertical-align: middle;
+        position: relative;
+        -webkit-appearance: none;
+    }
+    .k-input,
+    .k-textbox > input {
+        padding: 0;
+        width: 100%;
+        box-sizing: border-box;
+        border: 0;
+        outline: 0;
+        color: inherit;
+        background: transparent;
+        font: inherit;
+        flex: 1;
+        display: flex;
+        align-items: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
         -webkit-appearance: none;
     }
 
-    .k-input,
-    .k-textbox {
-        @include border-radius( $border-radius );
-        font: inherit;
-        outline: none;
-        padding: $input-padding-y $input-padding-x;
-
-        > input {
-            font: inherit;
-        }
-    }
-
-    .k-textbox {
-        outline: 0;
-        box-sizing: border-box;
-    }
-
-    .k-textbox:focus {
+    .k-textbox:focus,
+    .k-maskedtextbox:focus {
         box-shadow: $textbox-shadow;
     }
 
-    .k-input,
-    .k-textbox {
+    .k-textbox,
+    .k-maskedtextbox {
         &:disabled,
         &[disabled],
         &.k-state-disabled {

--- a/scss/input/_theme.scss
+++ b/scss/input/_theme.scss
@@ -18,7 +18,6 @@
     $focused-shadow: 0 0 0 2px rgba(0, 0, 0, .06) !default;
     $focused-checked-shadow: 0 0 0 2px rgba($accent, .3) !default;
 
-    .k-input,
     .k-textbox {
         @include appearance( "input" );
 


### PR DESCRIPTION
Styles for masked textbox.

Markup:

```
<kendo-maskedtextbox class="k-widget k-maskedtextbox">
  <input autocapitalize="off" autocomplete="off" autocorrect="off" class="k-input" />
</kendo-maskedtextbox> 
```

Question: since in jq-kendo masked textbox is simply `<input class="k-textbox" />`, should we also add the `k-textbox` class here and use those styles, while leaving the `k-maskedtextbox` class for scoping? Currently there is a slight duplication of styles e.g. longer selectors.