### PR TITLE
Fix grid headers styling

### DIFF
--- a/scss/common/_base.scss
+++ b/scss/common/_base.scss
@@ -51,14 +51,11 @@
 
 
     // Links
-    .k-link {
-        color: inherit;
-    }
     .k-link,
     .k-link:hover {
+        color: inherit;
         text-decoration: none;
     }
-
 
     // Form controls
     .k-button {

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -78,6 +78,7 @@
     }
 
     .k-grid-header th.k-header>.k-link {
+        display: block;
         margin: -$header-padding-x;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
Currently when Grid sorting is enabled, the link does not occupy the whole `<th>`. Also, when Bootstrap is included .k-link:hover color is blue