### PR TITLE
fix: incorrect upload icon size when Bootstrap is used. Closes teleri…

### DIFF
--- a/scss/upload/_layout.scss
+++ b/scss/upload/_layout.scss
@@ -211,6 +211,7 @@
         font-size: .57em;
         text-transform: uppercase;
         margin: ($uploaded-image-border / 2) $padding-y-lg;
+        box-sizing: content-box;
     }
 
     .k-file-invalid-extension-wrapper,


### PR DESCRIPTION
…k/kendo-angular-upload#39

The issue is caused by Bootstrap sets box-sizing: border-box