### PR TITLE
feat: enable custom builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 examples/**/build/
 .tmp/
 yarn.lock
+build/custom.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
     on_success: never
     secure: QFMZSJNCI5H5xzoIcDbJfzgR9AH7FuBD4tOyqRr/FMfEm1mV5eInvgUSmz0xFN3TpDMwJXKi41mrquK6/ey3DEgI0Jm5M32FTis+HahXp3R6zamD7+6Y0WaTxhILcULPqJVo2Ce4WtMqbmrEyk2xLFSYPhFt9wPna9aFO4j+OZw=
 node_js:
-  - '4'
+  - '6'
 env:
   - CXX=g++-4.8
 addons:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
  * Build CSS out of SCSS files using webpack, reusing the
  * configuration already in place for react / ng2 components.
@@ -32,6 +33,19 @@ BrowserSync.prototype = {
     }
 };
 
+let entry = { 'all': './build/all.js' };
+
+const components = process.env.COMPONENTS || null;
+if (components) {
+    // custom build
+    const fs = require('fs');
+    const path = require('path');
+    const imports = components.split(',')
+        .map(c => `require("./../scss/${c}.scss");`).join('\n')
+    fs.writeFileSync(path.join('build', 'custom.js'), imports);
+    entry = { 'custom': './build/custom.js' };
+}
+
 const inDevelopment = process.argv.find(v => v.includes('webpack-dev-server'))
 module.exports = require('@telerik/kendo-common-tasks')
     .webpackThemeConfig({ extract: true }, {
@@ -41,9 +55,7 @@ module.exports = require('@telerik/kendo-common-tasks')
             port: devServerPort
         },
         module: { loaders: [] },
-        entry: {
-            'all': './build/all.js'
-        },
+        entry: entry,
         plugins: inDevelopment ? [ new BrowserSync() ] : [],
         output: {
             path: path.join(__dirname, 'dist'),


### PR DESCRIPTION
Passing the COMPONENTS environment variable will build the CSS for the
specified components only. For example,

    COMPONENTS='panelbar,grid' npm run build

will output dist/custom.css that contains the styles used by the
PanelBar and Grid components.

closes #145 and telerik/kendo-angular2#187

@KirilNN has volunteered to add this to the theme docs.