### PR TITLE
fix: use calc to allow mixing of rem/px

### DIFF
--- a/scss/button/_layout.scss
+++ b/scss/button/_layout.scss
@@ -122,11 +122,6 @@
         &.k-state-focused,
         &:focus {
             outline: 0;
-
-            & > .k-button,
-            & > .k-button {
-                box-shadow: $button-focused-box-shadow;
-            }
         }
 
         &.k-widget {

--- a/scss/combobox/_layout.scss
+++ b/scss/combobox/_layout.scss
@@ -20,7 +20,7 @@
 
         >.k-dropdown-wrap {
             > .k-i-close {
-                right: ($icon-size + ($padding-y-lg * 3));
+                right: calc(#{$icon-size} + ($padding-y-lg * 3));
             }
         }
     }

--- a/scss/editor/_layout.scss
+++ b/scss/editor/_layout.scss
@@ -245,14 +245,14 @@
             align-items: center;
 
             .k-tool-icon {
-                padding: ($button-padding-x - 2px);
+                padding: calc(#{$button-padding-x} - 2px);
                 width: 1em;
                 height: 1em;
             }
         }
 
         .k-select {
-            padding: ($button-padding-x - 2px);
+            padding: calc(#{$button-padding-x} - 2px);
         }
     }
 

--- a/scss/menu/_layout.scss
+++ b/scss/menu/_layout.scss
@@ -35,7 +35,7 @@
 
         // Link
         .k-link {
-            padding: $nav-item-padding-y ($nav-item-padding-x + $icon-size) $nav-item-padding-y $nav-item-padding-x;
+            padding: $nav-item-padding-y calc(#{$nav-item-padding-x} + $icon-size) $nav-item-padding-y $nav-item-padding-x;
             color: inherit;
             display: flex;
             flex-direction: row;


### PR DESCRIPTION
Allows the theme to be mixed with bootstrap variables (enabling integration in kendo-theme-bootstrap)

The `$button-focused-box-shadow` was used in the _layout file is duplicated in the _theme file (and declared there), so it has been removed.

Part of #159