### PR TITLE
fix(dialog): limit height to viewport height

### DIFF
--- a/scss/dialog/_layout.scss
+++ b/scss/dialog/_layout.scss
@@ -12,12 +12,16 @@ $modal-inner-padding: $modal-title-padding !default;
         padding-top: 0;
         min-width: 450px;
         max-width: 100%;
+        max-height: 98vh;
         position: fixed;
         border-width: 0;
     }
 
     // Title bar
-    .k-dialog .k-window-title-bar {}
+    .k-dialog .k-window-titlebar {
+        flex-shrink: 0;
+    }
+
     .k-dialog .k-dialog-title {
         margin: 0;
         line-height: 1;

--- a/scss/window/_layout.scss
+++ b/scss/window/_layout.scss
@@ -70,6 +70,7 @@ $modal-overlay-color: #000 !default;
 
     // Actions
     .k-window-actions {
+        flex-shrink: 0;
         display: flex;
         flex-direction: row;
         align-items: center;


### PR DESCRIPTION
enables scrolling once the dialog content is more than the viewport height
makes sure that buttons and title stay visible