### PR TITLE
fix: numerictextbox spinner icons alignment.

### DIFF
--- a/scss/numerictextbox/_layout.scss
+++ b/scss/numerictextbox/_layout.scss
@@ -16,9 +16,17 @@
         .k-link {
             padding: 0 $button-padding-y;
             height: calc( (#{$button-calc-height}) / 2 );
+            overflow: hidden;
+
+            > .k-icon {
+                height: 100%;
+                overflow: hidden;
+
+                &.k-i-arrow-60-down {
+                    transform: translateY(-$padding-y);
+                }
+            }
         }
-
-
 
 
         // Compact

--- a/scss/numerictextbox/_theme.scss
+++ b/scss/numerictextbox/_theme.scss
@@ -9,6 +9,10 @@
         }
         .k-select {
             @include appearance( button );
+
+            > .k-state-selected {
+                color: $selected-text;
+            }
         }
 
         // Hovered state


### PR DESCRIPTION
Closes telerik/kendo-theme-default#161