### PR TITLE
fix: numerictextbox spinner appearance for IE10; selected spinner ico…

### DIFF
--- a/scss/numerictextbox/_layout.scss
+++ b/scss/numerictextbox/_layout.scss
@@ -14,6 +14,7 @@
             align-items: stretch;
         }
         .k-link {
+            display: block;
             padding: 0 $button-padding-y;
             height: calc( (#{$button-inner-calc-size}) / 2 );
             overflow: hidden;

--- a/scss/numerictextbox/_theme.scss
+++ b/scss/numerictextbox/_theme.scss
@@ -10,6 +10,10 @@
         .k-select {
             @include appearance( button );
             background-clip: padding-box;
+
+            > .k-state-selected {
+                @include appearance( pressed-button );
+            }
         }
 
         // Hovered state


### PR DESCRIPTION
…n color

Spinners apearance in IE10 issue is logged here: https://github.com/telerik/kendo-angular/issues/274