### PR TITLE
fix: remove grid focus outline.

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -123,6 +123,13 @@
         text-overflow: ellipsis;
     }
 
+    .k-grid td,
+    .k-grid th {
+        &:focus {
+            outline: none;
+        }
+    }
+
     .k-grouping-header,
     .k-filter-row th,
     .k-grid-add-row td {


### PR DESCRIPTION
Closes telerik/kendo-theme-default#199