### PR TITLE
fix: sparkline tooltip marker appearance.

### DIFF
--- a/scss/dataviz/_layout.scss
+++ b/scss/dataviz/_layout.scss
@@ -79,7 +79,7 @@ $chart-title-font-size: 1.143em !default;
         border-style: solid;
     }
 
-    .k-chart-shared-tooltip-marker {
+    .k-chart-shared-tooltip .k-chart-shared-tooltip-marker {
         display: block;
         width: 15px;
         height: 3px;


### PR DESCRIPTION
Closes telerik/kendo-theme-default#249