### PR TITLE
Fixes/treeview node size

### DIFF
--- a/scss/treeview/_layout.scss
+++ b/scss/treeview/_layout.scss
@@ -40,6 +40,7 @@
             align-items: center;
             align-content: center;
             vertical-align: middle;
+            position: relative;
         }
 
         // Expand / collapse

--- a/scss/treeview/_layout.scss
+++ b/scss/treeview/_layout.scss
@@ -62,7 +62,7 @@
         }
         .k-image,
         .k-sprite {
-            margin-right: 3px;
+            margin-right: $icon-spacing;
         }
 
 

--- a/scss/treeview/_layout.scss
+++ b/scss/treeview/_layout.scss
@@ -32,11 +32,13 @@
         // Link
         .k-in {
             margin: 0;
-            padding: $padding-y $padding-x;
+            padding: $button-padding-y;
             border: 1px solid;
             border-color: transparent;
             text-decoration: none;
-            display: inline-block;
+            display: inline-flex;
+            align-items: center;
+            align-content: center;
             vertical-align: middle;
         }
 

--- a/scss/treeview/_layout.scss
+++ b/scss/treeview/_layout.scss
@@ -73,7 +73,7 @@
 
             // Link
             .k-in {
-                padding: $padding-y-sm $padding-x-sm;
+                padding: $button-padding-y-sm;
             }
 
         }

--- a/scss/treeview/_layout.scss
+++ b/scss/treeview/_layout.scss
@@ -6,6 +6,7 @@
     .k-treeview {
         border-width: 0;
         background: none;
+        line-height: $form-line-height;
         cursor: default;
         overflow: auto;
         white-space: nowrap;


### PR DESCRIPTION
* Use `$form-line-height` for treeview to reduce size with bootstrap skin
* Use `$button-padding-y` on all sides
* Use `$icon-spacing` to more precisely position icon

Related to https://github.com/telerik/kendo-theme-bootstrap/issues/54