### PR TITLE
fix(panelbar): use correct variables for header padding

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -44,7 +44,7 @@ $popup-padding-x: 0 !default;
 $popup-padding-y: 0 !default;
 
 $header-padding-x: $padding-x !default;
-$header-padding-y: $padding-y !default;
+$header-padding-y: $padding-x !default;
 
 $form-line-height: $line-height !default;
 $form-line-height-em: $form-line-height * 1em !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -44,7 +44,7 @@ $popup-padding-x: 0 !default;
 $popup-padding-y: 0 !default;
 
 $header-padding-x: $padding-x !default;
-$header-padding-y: $padding-x !default;
+$header-padding-y: $padding-y * 2 !default;
 
 $form-line-height: $line-height !default;
 $form-line-height-em: $form-line-height * 1em !default;

--- a/scss/panelbar/_layout.scss
+++ b/scss/panelbar/_layout.scss
@@ -16,7 +16,7 @@
             display: block;
 
             > .k-link {
-                padding: $header-padding-x;
+                padding: $header-padding-y $header-padding-x;
                 color: inherit;
                 background: none;
                 text-decoration: none;


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-theme-bootstrap/issues/54