### PR TITLE
fix(popup): remove native focus outline from popup items

### DIFF
--- a/scss/popup/_layout.scss
+++ b/scss/popup/_layout.scss
@@ -11,6 +11,7 @@
 
         .k-item {
             cursor: pointer;
+            outline: none;
         }
     }
     .k-animation-container {


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-theme-bootstrap/issues/54