### PR TITLE
fix(gantt): use correct variables for toolbar padding

### DIFF
--- a/scss/gantt/_layout.scss
+++ b/scss/gantt/_layout.scss
@@ -47,7 +47,7 @@
 
     // Toolbar
     .k-gantt-toolbar {
-        padding: $padding-x;
+        padding: $toolbar-padding-y $toolbar-padding-x;
         border-width: 0 0 1px;
         border-style: solid;
         border-color: inherit;


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-theme-bootstrap/issues/54

Note: in theme-default, both `$toolbar-padding-x` and `$toolbar-padding-y` are equal to `$padding-x` which was the original value.