### PR TITLE
fix(mediaplayer): use correct padding for mediaplayer toolbar

### DIFF
--- a/scss/mediaplayer/_layout.scss
+++ b/scss/mediaplayer/_layout.scss
@@ -33,7 +33,7 @@
         right: 0;
     }
     .k-mediaplayer-toolbar {
-        padding: $padding-x;
+        padding: $toolbar-padding-y $toolbar-padding-x;
         border-width: 0;
         // sass-lint:disable no-important
         width: 100% !important;


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-theme-bootstrap/issues/54