### PR TITLE
fix(gantt): use vertical-align middle for gantt treelist content cells

### DIFF
--- a/scss/gantt/_layout.scss
+++ b/scss/gantt/_layout.scss
@@ -142,6 +142,9 @@
             overflow: hidden;
             overflow-x: scroll;
         }
+        .k-grid-content td {
+            vertical-align: middle;
+        }
     }
 
 


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-theme-bootstrap/issues/54