### PR TITLE
Fixes/grid row height

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -8,8 +8,6 @@
 
     $edit-cell-input-space: calc(-#{$cell-padding} - #{$input-border-width}) !default;
 
-    $delete-group-offset: calc(#{-$button-padding-y} - 1px) !default;
-
     .k-grid {
         display: block;
         position: relative;

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -174,18 +174,23 @@
 
         .k-link,
         .k-button.k-bare {
-            border-width: 0;
             padding: 0;
+            border-width: 0;
             display: inline-flex;
             align-items: center;
         }
 
-        .k-button.k-bare {
-            margin: $delete-group-offset auto $delete-group-offset $button-padding-x;
+        .k-link .k-icon {
+            margin-left: -( $icon-spacing / 2);
+            margin-right: $icon-spacing;
         }
 
-        .k-link .k-icon {
-            margin-right: $button-padding-y;
+        .k-button.k-bare {
+            margin-left: ( 2 * $icon-spacing );
+            margin-right: -( $icon-spacing / 2 );
+            padding: 0;
+            width: auto;
+            height: auto;
         }
     }
     .k-group-indicator + .k-group-indicator {

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -256,8 +256,6 @@
 
 
         .k-header {
-            height: button-size();
-            line-height: button-size();
             position: relative;
             vertical-align: bottom;
         }
@@ -281,8 +279,8 @@
         }
 
 
-        .k-header > .k-grid-filter,
-        .k-header > .k-header-column-menu {
+        .k-grid-filter,
+        .k-header-column-menu {
             padding: $button-padding-y;
             width: button-size();
             height: button-size();
@@ -297,10 +295,10 @@
             position: relative;
             z-index: 1;
         }
-        .k-header > .k-grid-filter {
+        .k-grid-filter {
             margin: -($cell-padding-y / 2) 0;
         }
-        .k-header > .k-header-column-menu {
+        .k-header-column-menu {
             margin: 0;
         }
 

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -155,6 +155,7 @@
         border-width: 0 0 1px;
         border-style: solid;
         border-color: inherit;
+        line-height: button-size();
     }
     .k-group-indicator,
     .k-drag-clue {

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -11,6 +11,8 @@
 
     $edit-cell-input-space: calc(-#{$cell-padding} - #{$input-border-width}) !default;
 
+    $delete-group-offset: calc(#{-$button-padding-y} - 1px) !default;
+
     .k-grid {
         display: block;
         position: relative;
@@ -150,16 +152,14 @@
         }
     }
 
-    // Grouping header
-    $delete-group-offset: calc(#{-$button-padding-y} - 1px) !default;
 
+    // Grouping header
     .k-grouping-header {
         display: block;
         padding: $cell-padding-y;
         border-width: 0 0 1px;
         border-style: solid;
         border-color: inherit;
-        line-height: button-size();
     }
     .k-group-indicator,
     .k-drag-clue {

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -307,9 +307,6 @@
     .k-grid-footer {
         border-width: 1px 0 0;
     }
-    .k-footer-template td {
-        height: button-size();
-    }
 
 
     // Filter row

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -331,7 +331,6 @@
         > span,
         .k-filtercell-wrapper {
             padding-right: calc( 2 * (#{$button-calc-size} + #{$cell-padding-y / 2}));
-            height: button-size();
             display: block;
             position: relative;
 

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -6,9 +6,6 @@
     $group-dropclue-size: 6px;
     $group-dropclue-line-size: $group-dropclue-size / 3;
 
-    $button-border-width: 1px;
-    $footer-cells-height: calc(#{$line-height-em} + #{$button-padding-y * 2} + #{$button-border-width * 2}) !default;
-
     $edit-cell-input-space: calc(-#{$cell-padding} - #{$input-border-width}) !default;
 
     $delete-group-offset: calc(#{-$button-padding-y} - 1px) !default;
@@ -196,9 +193,9 @@
     }
 
     .k-grouping-dropclue {
-        position: absolute;
         width: ($group-dropclue-size * 2);
-        height: calc( #{$button-calc-size} );
+        height: button-size();
+        position: absolute;
 
         &::before,
         &::after {
@@ -329,7 +326,7 @@
         > span,
         .k-filtercell-wrapper {
             padding-right: calc( 2 * (#{$button-calc-size} + #{$cell-padding-y / 2}));
-            height: calc( #{$button-calc-size} );
+            height: button-size();
             display: block;
             position: relative;
 
@@ -379,7 +376,7 @@
         }
 
         .k-dropdown-operator {
-            width: calc( #{$button-calc-size} );
+            width: button-size();
             flex: none;
             position: absolute;
             top: 0;

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -105,6 +105,15 @@
     // Grid header / footer
     .k-grid-header {
 
+        .k-header {
+            height: button-size();
+        }
+
+
+        .k-header > .k-link {
+            line-height: button-size();
+        }
+
 
         .k-grid-filter {}
         .k-grid-filter:hover {

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -140,4 +140,15 @@
         height: button-size();
     }
 
+
+    // Filter row
+    .k-filter-row {}
+    .k-filtercell {
+
+        > span,
+        .k-filtercell-wrapper {
+            height: button-size();
+        }
+    }
+
 }

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -113,10 +113,6 @@
 
         .k-header {
             height: button-size();
-        }
-
-
-        .k-header > .k-link {
             line-height: button-size();
         }
 

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -102,19 +102,8 @@
     }
 
 
-    // Grouping header
-    .k-grouping-header {
-        line-height: button-size();
-    }
-
-
     // Grid header / footer
     .k-grid-header {
-
-        .k-header {
-            height: button-size();
-            line-height: button-size();
-        }
 
 
         .k-grid-filter {}
@@ -128,22 +117,6 @@
         .k-grid-filter.k-state-active {
             color: $selected-text;
             background-color: $selected-bg;
-        }
-    }
-
-    .k-grid-footer {}
-    .k-footer-template td {
-        height: button-size();
-    }
-
-
-    // Filter row
-    .k-filter-row {}
-    .k-filtercell {
-
-        > span,
-        .k-filtercell-wrapper {
-            height: button-size();
         }
     }
 

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -135,4 +135,9 @@
         }
     }
 
+    .k-grid-footer {}
+    .k-footer-template td {
+        height: button-size();
+    }
+
 }

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -102,6 +102,12 @@
     }
 
 
+    // Grouping header
+    .k-grouping-header {
+        line-height: button-size();
+    }
+
+
     // Grid header / footer
     .k-grid-header {
 


### PR DESCRIPTION
As discussed with @yordanov, we should keep hardcoded or calculated values for dimensions from layout, unless needed. Such is the case with certain dimensions in the grid, which force larger metrics in Bootstrap.

I've moved those into grid/theme.

Fixes https://github.com/telerik/kendo-theme-bootstrap/issues/81