### PR TITLE
Fixes/button variables

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -342,7 +342,7 @@ Used to provide contrast between the background and foreground colors.
 <td>$button-pressed-text</td>
 <td>
     
-    $selected-text
+    $button-text
 </td>
 <td>The text color of pressed buttons.
 </td>
@@ -351,7 +351,7 @@ Used to provide contrast between the background and foreground colors.
 <td>$button-pressed-bg</td>
 <td>
     
-    $selected-bg
+    $button-bg
 </td>
 <td>The background color of pressed buttons.
 </td>
@@ -360,7 +360,7 @@ Used to provide contrast between the background and foreground colors.
 <td>$button-pressed-border</td>
 <td>
     
-    $selected-border
+    $button-border
 </td>
 <td>The border color of pressed buttons.
 </td>

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -232,15 +232,15 @@ $button-hovered-shadow: null !default;
 
 /// The text color of pressed buttons.
 /// @group buttons
-$button-pressed-text: $selected-text !default;
+$button-pressed-text: $button-text !default;
 
 /// The background color of pressed buttons.
 /// @group buttons
-$button-pressed-bg: $selected-bg !default;
+$button-pressed-bg: $button-bg !default;
 
 /// The border color of pressed buttons.
 /// @group buttons
-$button-pressed-border: $selected-border !default;
+$button-pressed-border: $button-border !default;
 
 /// The background gradient of pressed buttons.
 /// @group buttons

--- a/scss/button/_theme.scss
+++ b/scss/button/_theme.scss
@@ -73,16 +73,16 @@
     // Button group
     .k-button-group {
 
-        // Active state
-        .k-button:active,
-        .k-button.k-state-active {
-            @include appearance( pressed-button );
-        }
-
         // Focused state
         .k-button:focus,
         .k-button.k-state-focused {
             @include appearance( focused-button );
+        }
+
+        // Active state
+        .k-button:active,
+        .k-button.k-state-active {
+            @include appearance( pressed-button );
         }
 
     }

--- a/scss/button/_theme.scss
+++ b/scss/button/_theme.scss
@@ -14,7 +14,7 @@
         // Pressed state
         &:active,
         &.k-state-active {
-            @include fill( $button-text, $button-bg, $button-border, #{to top, $button-gradient} );
+            @include appearance( pressed-button );
             box-shadow: inset $button-pressed-shadow;
         }
 
@@ -101,7 +101,7 @@
     .k-split-button.k-button-group .k-button {
         &:active,
         &.k-state-active {
-            @include fill( $button-text, $button-bg, $button-border, #{to top, $button-gradient} );
+            @include appearance( pressed-button );
             box-shadow: inset $button-pressed-shadow;
         }
     }
@@ -119,7 +119,7 @@
         // Pressed state
         &:active,
         &.k-state-active {
-            @include fill( $button-text, $button-bg, $button-border, #{to top, $button-gradient} );
+            @include appearance( pressed-button );
             box-shadow: $button-pressed-shadow;
         }
 

--- a/scss/button/_theme.scss
+++ b/scss/button/_theme.scss
@@ -76,13 +76,19 @@
         // Focused state
         .k-button:focus,
         .k-button.k-state-focused {
-            @include appearance( focused-button );
+            box-shadow: inset 0 0 0 2px rgba(0, 0, 0, .13);
         }
 
-        // Active state
+        // Selected state
         .k-button:active,
         .k-button.k-state-active {
-            @include appearance( pressed-button );
+            @include fill( $selected-text, $selected-bg, $selected-border, none );
+        }
+
+        // Selected hover state
+        .k-button:active:hover,
+        .k-button.k-state-active:hover {
+            @include fill( $selected-text, $selected-bg, $selected-border, none );
         }
 
     }

--- a/scss/editor/_theme.scss
+++ b/scss/editor/_theme.scss
@@ -46,7 +46,7 @@
             }
 
             &.k-state-selected {
-                @include appearance( pressed-button );
+                @include fill( $selected-text, $selected-bg, $selected-border, none );
             }
         }
         .k-tool-group {

--- a/scss/scheduler/_theme.scss
+++ b/scss/scheduler/_theme.scss
@@ -35,7 +35,7 @@ $modal-header-border-color: #cccccc;
             @include appearance( button );
 
             &.k-state-hover { @include appearance( hovered-button ); }
-            &.k-state-selected { @include appearance( pressed-button ); }
+            &.k-state-selected { @include fill( $selected-text, $selected-bg, $selected-border, none ); }
         }
     }
 

--- a/scss/toolbar/_theme.scss
+++ b/scss/toolbar/_theme.scss
@@ -31,7 +31,7 @@
         // Button pressed state
         .k-button:active,
         .k-button.k-state-active {
-            @include appearance( pressed-button );
+            @include fill( $selected-text, $selected-bg, $selected-border, none );
             box-shadow: none;
         }
 


### PR DESCRIPTION
As per discussion with @yordanov, some of the sates were not correctly used. The resulting changes in action buttons, calendar, colorpicker, multiselect and numerictextbox are synced and approved.

The changes in short: a default (gray) button should derive its pressed state from `$button-` variables family, while the selected / toggled state will be based on `$selected-` variables family.

Fixes https://github.com/telerik/kendo-theme-default/issues/172