### PR TITLE
fix: remove inherited background from pickers

### DIFF
--- a/scss/autocomplete/_layout.scss
+++ b/scss/autocomplete/_layout.scss
@@ -3,7 +3,6 @@
     // Layout
     .k-autocomplete {
         @include border-radius( $border-radius );
-        border-width: 1px;
 
         .k-input {
             box-sizing: content-box;

--- a/scss/common/_forms.scss
+++ b/scss/common/_forms.scss
@@ -11,7 +11,6 @@
     .k-numerictextbox,
     .k-timepicker {
         width: 12.4em;
-        border-width: 0;
         line-height: $form-line-height;
         text-align: left;
         white-space: nowrap;
@@ -22,6 +21,17 @@
         &[dir='rtl'] {
             text-align: right;
         }
+    }
+    .k-colorpicker,
+    .k-combobox,
+    .k-dateinput,
+    .k-datepicker,
+    .k-datetimepicker,
+    .k-dropdown,
+    .k-numerictextbox,
+    .k-timepicker {
+        border-width: 0;
+        background-color: transparent;
     }
 
     .k-nodata {


### PR DESCRIPTION
Fixes https://github.com/telerik/kendo-theme-bootstrap/issues/83