### PR TITLE
fix(grid): multiheaders missing borders

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -259,6 +259,14 @@
         .k-header {
             position: relative;
             vertical-align: bottom;
+
+            &:first-child {
+                border-left-width: 0;
+            }
+
+            &.k-first {
+                border-left-width: 1px;
+            }
         }
 
 


### PR DESCRIPTION
Closes telerik/kendo-theme-default#298