### PR TITLE
fix(grid): expand/collapse icon is not centered

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -77,7 +77,7 @@
         .k-group-col,
         .k-hierarchy-col {
             padding: 0;
-            width: 30px;
+            width: $icon-size*2;
         }
 
         .k-grouping-row p {
@@ -98,8 +98,8 @@
         }
 
         .k-grouping-row .k-icon {
-            margin-left: addTwo(-1*$cell-padding-x, 7px);
-            margin-right: 7px;
+            margin-left: addTwo(-1*$cell-padding-x, $icon-size/2);
+            margin-right: $icon-size/2;
         }
 
         .k-group-footer td {

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -97,6 +97,11 @@
             text-overflow: none;
         }
 
+        .k-grouping-row .k-icon {
+            margin-left: addTwo(-1*$cell-padding-x, 7px);
+            margin-right: 7px;
+        }
+
         .k-group-footer td {
             border-style: solid;
             border-width: 1px 0;


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-theme-bootstrap/issues/82