### PR TITLE
chore(splitter): use currentColor instead of fixed color references

### DIFF
--- a/scss/splitter/_layout.scss
+++ b/scss/splitter/_layout.scss
@@ -94,6 +94,7 @@
 
     .k-splitter .k-resize-handle {
         display: none;
+        background-color: currentColor;
     }
 
     .k-splitbar-draggable-horizontal,

--- a/scss/splitter/_theme.scss
+++ b/scss/splitter/_theme.scss
@@ -1,16 +1,8 @@
 @include exports("splitter/theme") {
+
     $splitter-text: $widget-text;
 
-    .k-splitter {
-        .k-resize-handle {
-            background-color: $splitter-text;
-        }
-
-        .k-icon.k-collapse-prev,
-        .k-icon.k-collapse-next {
-            color: $splitter-text;
-        }
-    }
+    .k-splitter {}
 
     // Splitbar
     .k-splitbar {
@@ -20,25 +12,8 @@
         &.k-state-focused {
             color: $selected-text;
             background: $selected-bg;
-
-            .k-icon {
-                color: $button-pressed-text;
-            }
-
-            .k-resize-handle {
-                background-color: $button-pressed-text;
-            }
-        }
-
-        .k-icon {
-            color: $button-text;
-        }
-
-        .k-resize-handle {
-            background-color: $button-text;
         }
     }
-
     .k-splitbar-horizontal-hover,
     .k-splitbar-vertical-hover {
         @include appearance( hovered-button );
@@ -47,4 +22,5 @@
     .k-ghost-splitbar {
         @include appearance( hovered-button );
     }
+
 }


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-theme-bootstrap/pull/105