### PR TITLE
fix: Remove checkbox:checked border to center the check glyph

### DIFF
--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -147,6 +147,7 @@
 
     .k-checkbox:checked + .k-checkbox-label::before {
         content: "\e118";
+        border-width: 0;
     }
 
     .k-checkbox:checked:disabled + .k-checkbox-label::before {


### PR DESCRIPTION
Fix for the checkbox's check glyph being off-center