### PR TITLE
fix(NumericTextbox): Improve invalid state feedback icon positioning

### DIFF
--- a/scss/numerictextbox/_layout.scss
+++ b/scss/numerictextbox/_layout.scss
@@ -15,7 +15,7 @@
     }
 
     .k-numeric-wrap .k-i-warning {
-        position: absolute;
-        right: $spacer-x * 2;
+        align-self: center;
+        margin-right: $spacer-x / 2;
     }
 }


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo/issues/6796