### PR TITLE
Dateinput invalid styles

### DIFF
--- a/scss/datetime/_layout.scss
+++ b/scss/datetime/_layout.scss
@@ -58,6 +58,21 @@
 
     // Dateinput
     .k-dateinput {
+        position: relative;
+        border-width: 0;
+
+        .k-i-warning {
+            display: none;
+            position: absolute;
+            right: $padding-x;
+            top: 50%;
+            transform: translateY(-50%);
+            overflow: visible;
+        }
+
+        &.k-state-invalid .k-i-warning {
+            display: inline-block;
+        }
 
         // Compact
         @include compact {

--- a/scss/datetime/_layout.scss
+++ b/scss/datetime/_layout.scss
@@ -12,6 +12,24 @@
                 padding: $button-padding-y-sm;
             }
         }
+
+
+        .k-picker-wrap {
+            .k-i-warning {
+                display: none;
+                position: absolute;
+                right: $spacer * 2;
+                top: 50%;
+                transform: translateY(-50%);
+                overflow: visible;
+            }
+
+            &.k-state-invalid {
+                .k-i-warning {
+                    display: inline-block;
+                }
+            }
+        }
     }
 
     // Timepicker

--- a/scss/datetime/_theme.scss
+++ b/scss/datetime/_theme.scss
@@ -87,6 +87,17 @@
             .k-select { @include appearance( active-button ); }
         }
 
+        // Invalid state
+        .k-dateinput.k-state-invalid {
+            .k-textbox {
+                color: $error;
+                border-color: $error;
+            }
+
+            .k-i-warning {
+                color: $error;
+            }
+        }
     }
 
 }

--- a/scss/datetime/_theme.scss
+++ b/scss/datetime/_theme.scss
@@ -41,7 +41,20 @@
     }
 
     // Datepicker
-    .k-datepicker {}
+    .k-datepicker {
+        .k-picker-wrap.k-state-invalid {
+            transition: none;
+            border-color: $error;
+
+            .k-input {
+                color: $error;
+            }
+        }
+
+        .k-i-warning {
+            color: $error;
+        }
+    }
 
     // Timepicker
     .k-timepicker {}
@@ -88,7 +101,7 @@
         }
 
         // Invalid state
-        .k-dateinput.k-state-invalid {
+        &.k-state-invalid {
             .k-textbox {
                 color: $error;
                 border-color: $error;

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -206,21 +206,4 @@
             }
         }
     }
-    .k-dateinput {
-        position: relative;
-        border-width: 0;
-
-        .k-i-warning {
-            display: none;
-            position: absolute;
-            right: $padding-x;
-            top: 50%;
-            transform: translateY(-50%);
-            overflow: visible;
-        }
-
-        &.k-state-invalid .k-i-warning {
-            display: inline-block;
-        }
-    }
 }

--- a/scss/input/_theme.scss
+++ b/scss/input/_theme.scss
@@ -106,15 +106,4 @@
     fieldset legend {
         color: $header-text;
     }
-
-    .k-dateinput.k-state-invalid {
-        .k-textbox {
-            color: $error;
-            border-color: $error;
-        }
-
-        .k-i-warning {
-            color: $error;
-        }
-    }
 }


### PR DESCRIPTION
This branch moves the DateInput's invalid state styles from the Input to the DateTime group, and adds the invalid state styles for DateInput embedded inside a DatePicker. All dealing with https://github.com/telerik/kendo/issues/6874