### PR TITLE
fix(dialog): center action button text in Safari

### DIFF
--- a/scss/dialog/_layout.scss
+++ b/scss/dialog/_layout.scss
@@ -45,6 +45,13 @@
             white-space: normal;
             flex: 1;
             // sass-lint:enable no-important
+
+            &::before,
+            &::after {
+                // center stretched button content for Safari 10
+                content: '';
+                flex: 1 0 auto;
+            }
         }
         .k-button + .k-button {
             margin: 0;


### PR DESCRIPTION
Center dialog button text in Safari with the approach [shown here](http://stackoverflow.com/a/40483475/25427). May be removed with the next version of Safari at the end of the year. Decided to keep this in the Dialog so that it doesn't affect all buttons in the suite.

closes #158 
