### PR TITLE
feat(diagram): accent-contrast is used by diagram

### DIFF
--- a/scss/dataviz/_layout.scss
+++ b/scss/dataviz/_layout.scss
@@ -330,6 +330,7 @@ $chart-title-font-size: 1.143em !default;
     // export variables to allow use in scripts
     $exported: (
         accent: $accent,
+        accent-contrast: $accent-contrast,
         base: $base-bg,
         background: $widget-bg,
 


### PR DESCRIPTION
Need the accent-contrast in the variables for JS styling.

telerik/kendo#6657