### PR TITLE
fix: missing icon for success notification

### DIFF
--- a/scss/common/_icons.scss
+++ b/scss/common/_icons.scss
@@ -149,6 +149,7 @@
     .k-i-checkmark::before {content: "\e118";}
     .k-i-check-outline::before {content: "\e119";}
     .k-i-checkmark-outline::before {content: "\e119";}
+    .k-i-success::before {content: "\e119";}
     .k-i-check-circle::before {content: "\e11a";}
     .k-i-checkmark-circle::before {content: "\e11a";}
     .k-i-close::before {content: "\e11b";}


### PR DESCRIPTION
The new class will be added also in the WebComponentsIcons font by @lkarakoleva 