### PR TITLE
chore: add bootstrap compatibility check

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,8 @@
 *.tgz
 .tmp/
 .travis.yml
-dist/*.js
+dist/*.*
+!dist/all.css
 examples
 sass-lint.yml
 tests

--- a/build/twbs-compat.js
+++ b/build/twbs-compat.js
@@ -1,0 +1,3 @@
+// entry point for webpack
+require("./twbs-compat.scss");
+

--- a/build/twbs-compat.scss
+++ b/build/twbs-compat.scss
@@ -1,0 +1,2 @@
+@import "~bootstrap/scss/variables";
+@import "./../scss/all";

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "build": "webpack --optimize-minimize --bail",
     "watch": "webpack --watch",
     "embed-assets": "node build/embed-assets.js",
-    "test": "npm run lint && npm run build && npm run api-check",
+    "test": "npm run lint && npm run build && npm run api-check && npm run twbs-compat",
+    "twbs-compat": "webpack --env.twbs-compat",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "config": {
@@ -53,6 +54,7 @@
     }
   },
   "devDependencies": {
+    "bootstrap": "git://github.com/twbs/bootstrap.git#95f37e4c402df37db16781995ffa1592032df9c8",
     "@telerik/kendo-common-tasks": "^2.0.0",
     "cz-conventional-changelog": "^1.1.5",
     "ghooks": "^1.0.3",

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -251,7 +251,7 @@
 
         .k-field-info {
             display: inline-block;
-            font-size: ($font-size-xs / $font-size) * 1em;
+            font-size: .7142857em;
             margin: 0 $padding-x;
         }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,12 @@ if (components) {
     entry = { 'custom': './build/custom.js' };
 }
 
+const compat = process.argv.indexOf('--env.twbs-compat') > -1;
+
+if (compat) {
+    entry = { 'twbs-compat': './build/twbs-compat.js' };
+}
+
 const inDevelopment = process.argv.find(v => v.includes('webpack-dev-server'))
 module.exports = require('@telerik/kendo-common-tasks')
     .webpackThemeConfig({ extract: true }, {


### PR DESCRIPTION
Adds a build step that verifies that the theme is compatible with variables in Bootstrap v4. Works well against mixed unit errors.

To achieve this, there is a `devDependency` on bootstrap v4. This should be kept in sync with the version of the kendo-theme-bootstrap dependency, preferably the latest Bootstrap release version.