### PR TITLE
fix: use flexbox for dialog centering

### DIFF
--- a/scss/dialog/_layout.scss
+++ b/scss/dialog/_layout.scss
@@ -1,5 +1,16 @@
 @include exports('dialog/layout') {
 
+    .k-dialog-wrapper {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+
     .k-dialog {
         padding: 0;
         min-width: 450px;


### PR DESCRIPTION
keep .k-window-centered for backwards compatibility

closes telerik/kendo-angular#227