### PR TITLE
fix: loading icon position in MultiSelect and AutoComplete

### DIFF
--- a/scss/common/_forms.scss
+++ b/scss/common/_forms.scss
@@ -134,12 +134,16 @@
     .k-autocomplete,
     .k-dropdown-wrap,
     .k-multiselect {
-        .k-clear-value {
-            display: none;
+        .k-clear-value,
+        .k-i-loading {
             position: absolute;
             right: $padding-x;
             top: 50%;
             margin-top: -.5em;
+        }
+
+        .k-clear-value {
+            display: none;
         }
 
         &.k-state-focused,

--- a/scss/multiselect/_layout.scss
+++ b/scss/multiselect/_layout.scss
@@ -87,12 +87,5 @@
             float: left;
             width: auto;
         }
-
-        // Icons
-        .k-i-loading {
-            position: absolute;
-            right: $padding-x;
-            top: $padding-y-lg;
-        }
     }
 }


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-theme-default/issues/417