### PR TITLE
fix(dialog): alignment in IE11 and Firefox RTL

### DIFF
--- a/scss/dialog/_layout.scss
+++ b/scss/dialog/_layout.scss
@@ -9,13 +9,16 @@
         left: 0;
         width: 100%;
         height: 100%;
+
+        .k-dialog {
+            position: relative;
+        }
     }
 
     .k-dialog {
         padding: 0;
         min-width: 450px;
         position: fixed;
-
 
         // Centered
         &.k-dialog-centered {


### PR DESCRIPTION
see telerik/kendo-angular-dialog#53