### PR TITLE
fix(dialog): pager buttons appear above modal dialog

### DIFF
--- a/scss/dialog/_layout.scss
+++ b/scss/dialog/_layout.scss
@@ -9,6 +9,7 @@
         left: 0;
         width: 100%;
         height: 100%;
+        z-index: 10001;
 
         .k-dialog {
             position: relative;


### PR DESCRIPTION
Fix for https://github.com/telerik/kendo-theme-default/issues/438