### PR TITLE
fix(masked/numeric): Correct position of invalid state icon in RTL

### DIFF
--- a/scss/maskedtextbox/_layout.scss
+++ b/scss/maskedtextbox/_layout.scss
@@ -8,6 +8,14 @@
             right: $padding-x;
         }
 
+        .k-rtl &,
+        &[dir='rtl'] {
+            .k-i-warning {
+                right: auto;
+                left: $padding-x;
+            }
+        }
+
         &.k-state-invalid {
             .k-i-warning {
                 display: inline-block;

--- a/scss/numerictextbox/_layout.scss
+++ b/scss/numerictextbox/_layout.scss
@@ -14,6 +14,15 @@
                 padding: 0 $button-padding-y-sm;
             }
         }
+
+        .k-rtl &,
+        &[dir='rtl'] {
+            .k-numeric-wrap .k-i-warning {
+                align-self: center;
+                margin-right: 0;
+                margin-left: $spacer-x / 2;
+            }
+        }
     }
 
     .k-numeric-wrap .k-i-warning {


### PR DESCRIPTION
Fix the position of the invalid state icon in RTL mode in MaskedTextBox and NumericTextBox.

Deals with https://github.com/telerik/kendo-theme-bootstrap/issues/217