### PR TITLE
fix(Treelist): Add k-display-block class to handle frozen columns

### DIFF
--- a/scss/treelist/_layout.scss
+++ b/scss/treelist/_layout.scss
@@ -5,6 +5,10 @@
 
     // Base
     .k-treelist {
+        &.k-display-block.k-grid-lockedcolumns {
+            display: block;
+        }
+
         .k-status {
             padding: .4em .6em;
             line-height: 1.6em;


### PR DESCRIPTION
Dealing with frozen column misalignment: https://github.com/telerik/kendo-theme-bootstrap/issues/232