### PR TITLE
fix(NumericTB): Fix invalid state spinners color

### DIFF
--- a/scss/numerictextbox/_theme.scss
+++ b/scss/numerictextbox/_theme.scss
@@ -42,6 +42,11 @@
     .k-numeric-wrap.k-state-invalid {
         border-color: $error;
         color: $error;
+
+        .k-i-arrow-60-down,
+        .k-i-arrow-60-up {
+            color: $error;
+        }
     }
 
 }


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo-theme-default/issues/392