### PR TITLE
chore: fix lint warnings

### DIFF
--- a/scss/combobox/_layout.scss
+++ b/scss/combobox/_layout.scss
@@ -42,13 +42,13 @@
 
     .k-combobox-clearable {
         .k-input {
-            padding-right: addTwo($icon-size, $padding-x);
+            padding-right: add-two($icon-size, $padding-x);
         }
 
         &[dir='rtl'],
         .k-rtl & {
             .k-input {
-                padding-left: addTwo($icon-size, $padding-x);
+                padding-left: add-two($icon-size, $padding-x);
                 padding-right: $input-padding-x;
             }
         }

--- a/scss/common/_base.scss
+++ b/scss/common/_base.scss
@@ -50,7 +50,9 @@
 
     // hidden
     .k-hidden {
+        // sass-lint:disable no-important
         display: none !important;
+        // sass-lint:enable no-important
     }
 
 

--- a/scss/edit-form/_layout.scss
+++ b/scss/edit-form/_layout.scss
@@ -117,7 +117,7 @@
 
             .k-button + .k-button {
                 margin-left: 0;
-                margin-right: 0.5em;
+                margin-right: .5em;
             }
         }
     }

--- a/scss/gantt/_layout.scss
+++ b/scss/gantt/_layout.scss
@@ -14,10 +14,10 @@
             vertical-align: top;
         }
         .k-grid-header tr {
-            height: addThree( $line-height-em, 2 * $cell-padding-y, 1px );
+            height: add-three( $line-height-em, 2 * $cell-padding-y, 1px );
         }
         .k-grid-content tr {
-            height: addTwo( $line-height-em, 2 * $cell-padding-y );
+            height: add-two( $line-height-em, 2 * $cell-padding-y );
         }
 
 
@@ -128,7 +128,7 @@
             // sass-lint:enable no-important
         }
         .k-grid-header tr {
-            height: addThree( 2 * $line-height-em, 4 * $cell-padding-y, 2px );
+            height: add-three( 2 * $line-height-em, 4 * $cell-padding-y, 2px );
             vertical-align: bottom;
         }
         .k-grid-content {

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -88,7 +88,7 @@
         .k-group-col,
         .k-hierarchy-col {
             padding: 0;
-            width: $icon-size*2;
+            width: ($icon-size * 2);
         }
 
         .k-grouping-row p {
@@ -109,8 +109,8 @@
         }
 
         .k-grouping-row .k-icon {
-            margin-left: addTwo(-1*$cell-padding-x, $icon-size/2);
-            margin-right: $icon-size/2;
+            margin-left: add-two(-1 * $cell-padding-x, $icon-size / 2);
+            margin-right: $icon-size / 2;
         }
 
         .k-group-footer td {

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -88,7 +88,7 @@
     .k-checkbox-label,
     .k-radio-label {
         position: relative;
-        padding-left: addTwo($icon-size, ($padding-x-lg / 2));
+        padding-left: add-two($icon-size, ($padding-x-lg / 2));
         vertical-align: text-top;
         cursor: pointer;
         display: inline-flex;
@@ -298,7 +298,7 @@
                 width: $inline-form-element-width;
                 text-align: right;
                 line-height: $line-height;
-                padding: addTwo($padding-y, $input-border-width) 0;
+                padding: add-two($padding-y, $input-border-width) 0;
                 padding-right: $padding-x-lg;
                 align-self: center;
             }

--- a/scss/map/_layout.scss
+++ b/scss/map/_layout.scss
@@ -25,7 +25,7 @@
         // Marker
         .k-marker {
             margin: -32px 0 0 -16px;
-            font-size: $font-size*2;
+            font-size: $font-size * 2;
             cursor: pointer;
             position: absolute;
         }
@@ -58,8 +58,8 @@
     // Navigator
     .k-navigator {
         margin: $spacer-x;
-        width: addTwo( (3 * $icon-size), $map-navigator-padding );
-        height: addTwo( (3 * $icon-size), $map-navigator-padding );
+        width: add-two( (3 * $icon-size), $map-navigator-padding );
+        height: add-two( (3 * $icon-size), $map-navigator-padding );
         box-sizing: content-box;
         border-radius: 50%;
         position: relative;

--- a/scss/mediaplayer/_layout.scss
+++ b/scss/mediaplayer/_layout.scss
@@ -74,7 +74,9 @@
         left: 0;
     }
     .k-mediaplayer-seekbar .k-slider-track {
+        // sass-lint:disable no-important
         width: 100% !important;
+        // sass-lint:enable no-important
         border-radius: 0;
     }
 

--- a/scss/mediaplayer/_theme.scss
+++ b/scss/mediaplayer/_theme.scss
@@ -14,7 +14,7 @@
 
 
     .k-mediaplayer-toolbar {
-        background-color: rgba($toolbar-bg, 0.85);
+        background-color: rgba($toolbar-bg, .85);
     }
 
 }

--- a/scss/menu/_layout.scss
+++ b/scss/menu/_layout.scss
@@ -113,7 +113,7 @@
 
         .k-link {
             padding: $list-item-padding-y $list-item-padding-x;
-            padding-right: addTwo( (2 * $list-item-padding-x), $icon-size);
+            padding-right: add-two( (2 * $list-item-padding-x), $icon-size);
             color: inherit;
             display: flex;
             flex-direction: row;
@@ -183,7 +183,7 @@
 
             .k-link {
                 padding-right: $list-item-padding-x;
-                padding-left: addTwo( (2 * $list-item-padding-x), $icon-size);
+                padding-left: add-two( (2 * $list-item-padding-x), $icon-size);
             }
         }
     }

--- a/scss/mixins/utils/_functions.scss
+++ b/scss/mixins/utils/_functions.scss
@@ -1,5 +1,5 @@
 // Add two
-@function addTwo( $one, $two, $multiplier: 1 ) {
+@function add-two( $one, $two, $multiplier: 1 ) {
     $_unit-1: unit($one);
     $_unit-2: unit($two);
 
@@ -16,7 +16,7 @@
 }
 
 
-@function addThree( $one, $two, $three, $multiplier: 1 ) {
+@function add-three( $one, $two, $three, $multiplier: 1 ) {
     $_unit-1: unit($one);
     $_unit-2: unit($two);
     $_unit-3: unit($three);

--- a/scss/pivotgrid/_layout.scss
+++ b/scss/pivotgrid/_layout.scss
@@ -14,7 +14,7 @@
     .k-fieldselector .k-list li.k-item {
         @include border-radius( $border-radius );
         padding: $button-padding-y $button-padding-x;
-        padding-right: addTwo( ($button-padding-x * 2), ($icon-size * 2) );
+        padding-right: add-two( ($button-padding-x * 2), ($icon-size * 2) );
         font-size: $font-size;
         line-height: $form-line-height;
         text-align: left;

--- a/scss/popup/_layout.scss
+++ b/scss/popup/_layout.scss
@@ -112,7 +112,7 @@
         display: block;
         position: relative;
         padding: $padding-x;
-        height: addThree(4 * $padding-y, $form-line-height-em, 2 * $button-padding-y);
+        height: add-three(4 * $padding-y, $form-line-height-em, 2 * $button-padding-y);
         box-sizing: border-box;
 
         > .k-textbox {

--- a/scss/toolbar/_theme.scss
+++ b/scss/toolbar/_theme.scss
@@ -31,8 +31,8 @@
             &::before {
                 content: "";
                 background-color: currentColor;
-                -webkit-transition: opacity 0.2s ease-in-out;
-                transition: opacity 0.2s ease-in-out;
+                -webkit-transition: opacity .2s ease-in-out;
+                transition: opacity .2s ease-in-out;
             }
 
             &::after {
@@ -64,7 +64,7 @@
         .k-button.k-state-hover {
 
             &::before {
-                opacity: 0.07;
+                opacity: .07;
                 z-index: 1;
             }
         }
@@ -89,7 +89,7 @@
             box-shadow: none;
 
             &::after {
-                opacity: 0.08;
+                opacity: .08;
                 z-index: 1;
             }
         }
@@ -115,10 +115,10 @@
             }
 
             &::before {
-                opacity: 0.07;
+                opacity: .07;
             }
             &::after {
-                opacity: 0.13;
+                opacity: .13;
             }
         }
         .k-split-button {

--- a/scss/tooltip/_layout.scss
+++ b/scss/tooltip/_layout.scss
@@ -21,7 +21,7 @@ $tooltip-callout-size: 12px !default;
     }
 
     .k-tooltip-closable {
-        padding: ($padding-y*3) ($padding-x*2);
+        padding: ($padding-y * 3) ($padding-x * 2);
     }
 
     .k-tooltip-closable .k-tooltip-content {


### PR DESCRIPTION
Pending warning

```
scss/edit-form/_layout.scss
  57:18  warning  Property `padding` should be written more concisely as `0 0 $spacer-y` instead of `0 0 $spacer-y 0`  shorthand-values
  64:18  warning  Property `padding` should be written more concisely as `0 0 $spacer-y` instead of `0 0 $spacer-y 0`  shorthand-values

scss/editor/_layout.scss
   57:18  warning  Property `padding` should be written more concisely as `$toolbar-padding-y` instead of `$toolbar-padding-y $toolbar-padding-y`  shorthand-values
  291:21  warning  Property `margin` should be written more concisely as `$spacer-y 0 0` instead of `$spacer-y 0 0 0`  shorthand-values
  320:21  warning  Property `margin` should be written more concisely as `0 0 $spacer-y` instead of `0 0 $spacer-y 0`  shorthand-values

scss/scrollview/_layout.scss
  155:14  warning  Property `padding` should be written more concisely as `$padding-y 0 0` instead of `$padding-y 0 0 0`  shorthand-values

scss/tabstrip/_layout.scss
  38:13  warning  Attribute-selector should be nested within its parent Class  force-attribute-nesting

✖ 7 problems (0 errors, 7 warnings)
```

Not sure if we should take care of those, as the compiler already does, namely the optimized form of shorthand values...

/cc @gyoshev @inikolova 

NOTE: we should merge this after 2017 R2