### PR TITLE
fix(Grid): Add validation tooltip styling

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -212,7 +212,7 @@
                 }
             }
         }
-        
+
         .k-tooltip.k-tooltip-validation {
             display: block;
             position: absolute;

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -214,11 +214,11 @@
         }
 
         .k-tooltip.k-tooltip-validation {
-            display: block;
+            display: flex;
             position: absolute;
             width: auto;
             padding: $padding-y $padding-x;
-            border-radius: $border-radius;
+            @include border-radius($border-radius);
 
             .k-callout {
                 display: block;

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -212,6 +212,18 @@
                 }
             }
         }
+        
+        .k-tooltip.k-tooltip-validation {
+            display: block;
+            position: absolute;
+            width: auto;
+            padding: $padding-y $padding-x;
+            border-radius: $border-radius;
+
+            .k-callout {
+                display: block;
+            }
+        }
     }
 
     // Toolbar

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -218,7 +218,7 @@
             position: absolute;
             width: auto;
             padding: $padding-y $padding-x;
-            @include border-radius($border-radius);
+            border-radius: $border-radius;
 
             .k-callout {
                 display: block;

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -9,6 +9,9 @@
     $grid-grouping-row-text: $text-color !default;
     $grid-grouping-row-bg: darken($bg-color, 7%) !default;
 
+    $tooltip-color: $accent-contrast !default;
+    $tooltip-bg: $accent !default;
+
     .k-grid-header,
     .k-header,
     .k-grid-header-wrap,
@@ -87,6 +90,28 @@
 
             &::after {
                 background-color: $grid-chrome-text;
+            }
+        }
+
+        .k-tooltip.k-tooltip-validation {
+            color: $tooltip-color;
+            background-color: $tooltip-bg;
+            @include border-radius($border-radius);
+
+            .k-callout-n {
+                border-bottom-color: $tooltip-bg;
+            }
+
+            .k-callout-e {
+                border-left-color: $tooltip-bg;
+            }
+
+            .k-callout-s {
+                border-top-color: $tooltip-bg;
+            }
+
+            .k-callout-w {
+                border-right-color: $tooltip-bg;
             }
         }
     }

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -96,7 +96,6 @@
         .k-tooltip.k-tooltip-validation {
             color: $tooltip-color;
             background-color: $tooltip-bg;
-            @include border-radius($border-radius);
 
             .k-callout-n {
                 border-bottom-color: $tooltip-bg;


### PR DESCRIPTION
Adding missing validation tooltip styling in the Grid described in https://github.com/telerik/kendo-theme-bootstrap/issues/218