### PR TITLE
fix: improve performance in IE

### DIFF
--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -148,7 +148,7 @@
         opacity: .5;
     }
 
-    .k-checkbox:disabled + .k-checkbox-label:hover::before {
+    .k-checkbox:disabled + .k-checkbox-label::before {
         border-width: 1px;
         border-style: solid;
     }

--- a/scss/toolbar/_layout.scss
+++ b/scss/toolbar/_layout.scss
@@ -42,6 +42,9 @@
 
         // Split button
         .k-split-button {
+            .k-button:hover {
+                z-index: 2;
+            }
 
             &:focus {
                 outline: none;

--- a/scss/toolbar/_theme.scss
+++ b/scss/toolbar/_theme.scss
@@ -69,17 +69,10 @@
             }
         }
         .k-split-button {
-
             .k-button:hover,
             .k-button.k-state-hover {
                 @include appearance( hovered-button );
             }
-            .k-button:hover + .k-button {
-                border-left-color: $button-hovered-border;
-            }
-        }
-        .k-split-button .k-button:hover + .k-button {
-            border-left-color: $button-hovered-border;
         }
 
 


### PR DESCRIPTION
Using ':hover' and '+' leads to style recalculation on every mouse move in IE.
As it turns out, we do not need these classes:
- the toolbar split button can use the z-index and negative margin approach, like the button group
- the checkbox style does not appear to have any effect whatsoever