### PR TITLE
Splitter - Corrected spelling to fix missing scrollbars

### DIFF
--- a/scss/splitter/_layout.scss
+++ b/scss/splitter/_layout.scss
@@ -13,7 +13,7 @@
         .k-pane {
             overflow: hidden;
         }
-        .k-scrollabele {
+        .k-scrollable {
             overflow: auto;
         }
         .k-splitter-resizing {


### PR DESCRIPTION
The scrollbars were not appearing when using the Splitter with larger contents. Tracked it down to typo in the k-scrollable class name.