### PR TITLE
fix(datepicker): wrong width of the internal DateInput component in IE11

### DIFF
--- a/scss/datetime/_layout.scss
+++ b/scss/datetime/_layout.scss
@@ -20,11 +20,13 @@
         }
 
         .k-dateinput {
-            width: calc(100% - #{button-inner-size()});
+            width: 100%;
+            flex: 1;
         }
 
         .k-dateinput-wrap {
             border: 0;
+            @include border-left-radius-only();
         }
 
         .k-rtl &,


### PR DESCRIPTION
telerik/kendo-theme-default#521