### PR TITLE
fix(map): Add 100% height to the Map's scroll container

### DIFF
--- a/scss/map/_layout.scss
+++ b/scss/map/_layout.scss
@@ -40,6 +40,9 @@
             z-index: 1000;
         }
 
+        .km-scroll-container {
+            height: 100%;
+        }
     }
 
 


### PR DESCRIPTION
Deals with map not displaying in certain scenarios. https://github.com/telerik/kendo-theme-bootstrap/issues/240