### PR TITLE
fix(combobox): misaligned loading indicator

### DIFF
--- a/scss/combobox/_layout.scss
+++ b/scss/combobox/_layout.scss
@@ -5,7 +5,8 @@
             > .k-i-loading {
                 top: 50%;
                 transform: translateY(-50%);
-                margin-right: $padding-x;
+                right: $padding-x-lg / 2;
+                margin-top: 0;
             }
 
             > .k-i-close {


### PR DESCRIPTION
Closes: https://github.com/telerik/kendo-theme-default/issues/537