### PR TITLE
Contrast

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -99,8 +99,8 @@ Used for primary buttons and for elements of primary importance across the theme
 <tr>
 <td>$accent-contrast</td>
 <td>
-    <span class="color-preview" style="background-color: #ffffff"></span>
-    #ffffff
+    
+    contrast-wcag( $accent )
 </td>
 <td>The color used along with the accent color denoted by $accent.<br/>
 Used to provide contrast between the background and foreground colors.
@@ -179,21 +179,21 @@ Used to provide contrast between the background and foreground colors.
 </td>
 </tr>
 <tr>
-<td>$selected-text</td>
-<td>
-    
-    $accent-contrast
-</td>
-<td>The text color of selected items.
-</td>
-</tr>
-<tr>
 <td>$selected-bg</td>
 <td>
     
     $accent
 </td>
 <td>The background of selected items.
+</td>
+</tr>
+<tr>
+<td>$selected-text</td>
+<td>
+    
+    contrast-wcag( $selected-bg )
+</td>
+<td>The text color of selected items.
 </td>
 </tr>
 <tr>

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -116,7 +116,7 @@ $accent: #ff6358 !default;
 
 /// The color used along with the accent color denoted by $accent.
 /// Used to provide contrast between the background and foreground colors.
-$accent-contrast: #ffffff !default;
+$accent-contrast: contrast-wcag( $accent ) !default;
 
 $text-color: #656565 !default;
 $bg-color: #ffffff !default;
@@ -140,10 +140,10 @@ $hovered-border: rgba( black, .15 ) !default;
 /// The gradient background of hovered items.
 $hovered-gradient: $hovered-bg, darken( $hovered-bg, 2% ) !default;
 
-/// The text color of selected items.
-$selected-text: $accent-contrast !default;
 /// The background of selected items.
 $selected-bg: $accent !default;
+/// The text color of selected items.
+$selected-text: contrast-wcag( $selected-bg ) !default;
 /// The border color of selected items.
 $selected-border: rgba( black, .1 ) !default;
 /// The gradient background of selected items.

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -2,13 +2,13 @@
     $grid-chrome-text: $header-text !default;
     $grid-chrome-bg: $header-bg !default;
     $grid-chrome-border: $border-color !default;
-    $grid-alt-bg: rgba( contrast( $panel-bg ), .04) !default;
+    $grid-alt-bg: rgba( contrast-wcag( $panel-bg ), .04) !default;
 
     $grid-selected-text: $grid-chrome-text !default;
     $grid-selected-bg: rgba($selected-bg, .25) !default;
     $grid-grouping-row-text: $text-color !default;
     $grid-grouping-row-bg: darken($bg-color, 7%) !default;
-    $grid-sorted-bg: rgba( contrast( $panel-bg ), .02 ) !default;
+    $grid-sorted-bg: rgba( contrast-wcag( $panel-bg ), .02 ) !default;
 
     $tooltip-color: $accent-contrast !default;
     $tooltip-bg: $accent !default;

--- a/scss/mixins/_colors.scss
+++ b/scss/mixins/_colors.scss
@@ -45,11 +45,6 @@
 
     @return $yiq;
 }
-@function contrast($color, $dark: #000000, $light: #ffffff) {
-    $yiq: yiq($color);
-    $out: if($yiq >= 128, $dark, $light);
-    @return $out;
-}
 @function contrast-yiq($color, $dark: #000000, $light: #ffffff) {
     $yiq: yiq($color);
     $out: if($yiq >= 128, $dark, $light);

--- a/scss/mixins/_colors.scss
+++ b/scss/mixins/_colors.scss
@@ -1,3 +1,7 @@
+@import "vendor/color-helpers/math";
+@import "vendor/color-helpers/contrast";
+
+
 @function tint( $color, $percentage: 10 ) {
     @return mix( white, $color, $percentage );
 }
@@ -44,5 +48,17 @@
 @function contrast($color, $dark: #000000, $light: #ffffff) {
     $yiq: yiq($color);
     $out: if($yiq >= 128, $dark, $light);
+    @return $out;
+}
+@function contrast-yiq($color, $dark: #000000, $light: #ffffff) {
+    $yiq: yiq($color);
+    $out: if($yiq >= 128, $dark, $light);
+    // @debug yiq;
+    @return $out;
+}
+@function contrast-wcag($color, $dark: #000000, $light: #ffffff) {
+    $luma: ch-color-luminance($color);
+    $out: if($luma < .5, $light, $dark);
+    // @debug $luma;
     @return $out;
 }

--- a/scss/mixins/vendor/color-helpers/_contrast.scss
+++ b/scss/mixins/vendor/color-helpers/_contrast.scss
@@ -1,0 +1,56 @@
+// From https://github.com/voxpelli/sass-color-helpers
+
+
+@function ch-color-luminance($color) {
+  // Adapted from: https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/color.js
+  // Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+  $rgba: red($color), green($color), blue($color);
+  $rgba2: ();
+
+  @for $i from 1 through 3 {
+    $rgb: nth($rgba, $i);
+    $rgb: $rgb / 255;
+
+    $rgb: if($rgb < .03928, $rgb / 12.92, ch-pow(($rgb + .055) / 1.055, 2.4, 16));
+
+    $rgba2: append($rgba2, $rgb);
+  }
+
+  @return .2126 * nth($rgba2, 1) + .7152 * nth($rgba2, 2) + 0.0722 * nth($rgba2, 3);
+}
+
+@function ch-color-contrast($color1, $color2) {
+  // Adapted from: https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/color.js
+  // Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+  $luminance1: ch-color-luminance($color1) + .05;
+  $luminance2: ch-color-luminance($color2) + .05;
+  $ratio: $luminance1 / $luminance2;
+
+  @if $luminance2 > $luminance1 {
+    $ratio: 1 / $ratio;
+  }
+
+  $ratio: round($ratio * 10) / 10;
+
+  @return $ratio;
+}
+
+@function ch-best-color-contrast($base, $colors: (#fff, #000), $tolerance: 0) {
+  $best: nth($colors, 1);
+  $contrast: ch-color-contrast($base, $best);
+
+  @for $i from 2 through length($colors) {
+    $currentColor: nth($colors, $i);
+    $currentContrast: ch-color-contrast($base, $currentColor);
+    @if ($currentContrast - $contrast > $tolerance) {
+      $best: $currentColor;
+      $contrast: $currentContrast;
+    }
+  }
+
+  @if ($contrast < 3) {
+    @warn "Contrast ratio of #{$best} on #{$base} is pretty bad, just #{$contrast}";
+  }
+
+  @return $best;
+}

--- a/scss/mixins/vendor/color-helpers/_math.scss
+++ b/scss/mixins/vendor/color-helpers/_math.scss
@@ -1,0 +1,53 @@
+// From https://github.com/voxpelli/sass-color-helpers
+
+
+@function ch-max($v1, $v2) {
+  @return if($v1 > $v2, $v1, $v2);
+}
+
+@function ch-min($v1, $v2) {
+  @return if($v1 < $v2, $v1, $v2);
+}
+
+@function ch-gcd($a, $b) {
+  // From: http://rosettacode.org/wiki/Greatest_common_divisor#JavaScript
+  @if ($b != 0) {
+    @return ch-gcd($b, $a % $b);
+  } @else {
+    @return abs($a);
+  }
+}
+
+@function ch-pow($base, $exponent, $prec: 12) {
+  // Handles decimal exponents by trying to convert them into a fraction and then use a nthRoot-algorithm for parts of the calculation
+  @if (floor($exponent) != $exponent) {
+    $prec2 : ch-pow(10, $prec);
+    $exponent: round($exponent * $prec2);
+    $denominator: ch-gcd($exponent, $prec2);
+    @return ch-nth-root(ch-pow($base, $exponent / $denominator), $prec2 / $denominator, $prec);
+  }
+
+  $value: $base;
+  @if $exponent > 1 {
+    @for $i from 2 through $exponent {
+      $value: $value * $base;
+    }
+  } @else if $exponent < 1 {
+    @for $i from 0 through -$exponent {
+      $value: $value / $base;
+    }
+  }
+
+  @return $value;
+}
+
+@function ch-nth-root($num, $n: 2, $prec: 12) {
+  // From: http://rosettacode.org/wiki/Nth_root#JavaScript
+  $x: 1;
+
+  @for $i from 0 through $prec {
+    $x: 1 / $n * (($n - 1) * $x + ($num / ch-pow($x, $n - 1)));
+  }
+
+  @return $x;
+}

--- a/scss/notification/_theme.scss
+++ b/scss/notification/_theme.scss
@@ -1,16 +1,16 @@
 // TODO: extract or remove alert color variables
 $alert-info-border: $info !default;
-$alert-info-text: $accent-contrast !default;
 $alert-info-bg: $info !default;
+$alert-info-text: contrast-wcag( $alert-info-bg ) !default;
 $alert-success-border: $success !default;
-$alert-success-text: $accent-contrast !default;
 $alert-success-bg: $success !default;
+$alert-success-text: contrast-wcag( $alert-success-bg ) !default;
 $alert-warning-border: $warning !default;
-$alert-warning-text: $validator-warning-text !default;
 $alert-warning-bg: $warning !default;
+$alert-warning-text: contrast-wcag( $alert-warning-bg ) !default;
 $alert-error-border: $error !default;
-$alert-error-text: $accent-contrast !default;
 $alert-error-bg: $error !default;
+$alert-error-text: contrast-wcag( $alert-error-bg ) !default;
 
 @include exports("notification/theme") {
 

--- a/third-party.md
+++ b/third-party.md
@@ -1,0 +1,11 @@
+This Kendo UI theme uses code from the [Sass Color Helpers project](https://github.com/voxpelli/sass-color-helpers).
+
+The MIT License (MIT)
+
+Copyright © 2017 Pelle Wessman <pelle@kodfabrik.se>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
In some edge cases the current contrast function did not yield correct results.

I changed the contrast function to use the behaviour [described by WCAG](https://www.w3.org/WAI/GL/wiki/Relative_luminance) (sample code below), the one that's going to be in the upcoming `color( ... contrast(...) )` function.

I've also amended the colors in notification to use contrast.

```scss
@function adjust-channel( $channel ) {
  @if ($channel < 0.03928) {
    @return ($channel / 12.92)
  }
  @else {
    @return pow(($channel + 0.055) / 1.055, 2.4 )
  }
}

@function get-luminance( $color ) {
    $r: red($color) / 255;
    $g: green($color) / 255;
    $b: blue($color) / 255;
    
    $R: adjust-channel($r);
    $G: adjust-channel($g);
    $B: adjust-channel($b);
    
    @return (0.2126*$R + 0.7152*$G + 0.0722*$B);
}


@function contrast-wcag($color, $dark: #000000, $light: #ffffff) {
    $luminance: get-luminance($color);
    $out: if($luminance < .5, $light, $dark );
    @return $out;
}
```
Note: because `pow` is part of sassmath, I've resorted to using [voxpelli/sass-color-helpers](https://github.com/voxpelli/sass-color-helpers).