### PR TITLE
feat: add variables to disabled mixin

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -389,3 +389,7 @@ $chart-area-opacity: .8 !default;
 $icon-size: 16px;
 $icon-size-lg: 32px;
 $icon-spacing: 4px !default;
+
+// Disabled mixin variables
+$disabled-filter: grayscale(.1) !default;
+$disabled-opacity: .6 !default;

--- a/scss/mixins/_disabled.scss
+++ b/scss/mixins/_disabled.scss
@@ -2,8 +2,8 @@
 @mixin disabled {
     outline: none;
     cursor: default;
-    opacity: .6;
-    filter: grayscale(.1);
+    opacity: $disabled-opacity;
+    filter: $disabled-filter;
     pointer-events: none;
 }
 @include exports("placeholder/disabled") {


### PR DESCRIPTION
#547 

Adds variables for the disabled mixin to allow for styling customization of the disabled state of components

Includes:
- opacity
- grayscale