### PR TITLE
fix(tabstrip): use scoped tabstrip variables for styling

### DIFF
--- a/scss/tabstrip/_theme.scss
+++ b/scss/tabstrip/_theme.scss
@@ -1,4 +1,4 @@
-$tabstrip-border: rgba(0, 0, 0, .08) !default;
+$tabstrip-border: $panel-border !default;
 $tabstrip-item-text: $link-text !default;
 $tabstrip-item-bg: transparent !default;
 $tabstrip-item-border: transparent !default;
@@ -15,12 +15,12 @@ $tabstrip-content-border: $panel-bg !default;
 @include exports('tabstrip/theme') {
 
     .k-tabstrip {
-        //border-color: $tabstrip-border;
+        border-color: $tabstrip-border;
 
         .k-item {
-            // border-color: $tabstrip-item-border;
+            border-color: $tabstrip-item-border;
             color: $tabstrip-item-text;
-            //background-color: $tabstrip-item-bg;
+            background-color: $tabstrip-item-bg;
             background-clip: padding-box;
 
             .k-ie11 &,
@@ -31,9 +31,9 @@ $tabstrip-content-border: $panel-bg !default;
 
             &:hover,
             &.k-state-hover {
-                // border-color: $tabstrip-item-hovered-border;
+                border-color: $tabstrip-item-hovered-border;
                 color: $tabstrip-item-hovered-text;
-                // background-color: $tabstrip-item-hovered-border;
+                background-color: $tabstrip-item-hovered-border;
             }
 
             &.k-state-active {
@@ -44,9 +44,9 @@ $tabstrip-content-border: $panel-bg !default;
         }
 
         > .k-content {
-            // border-color: $tabstrip-content-border;
-            // color: $tabstrip-content-text;
-            // background-color: $tabstrip-content-bg;
+            border-color: $tabstrip-content-border;
+            color: $tabstrip-content-text;
+            background-color: $tabstrip-content-bg;
             background-clip: padding-box;
 
             .k-ie11 &,

--- a/scss/tabstrip/_theme.scss
+++ b/scss/tabstrip/_theme.scss
@@ -1,16 +1,26 @@
-$tabstrip-tabs-color: $accent !default;
-$tabstrip-border-color: rgba(0, 0, 0, .08) !default;
-$tabstrip-hover-color: blend-multiply($accent, darken($widget-bg, 8%)) !default;
-$tabstrip-active-color: $base-text !default;
-$tabstrip-active-background-color: desaturate($widget-bg, 1%) !default;
-$tabstrip-disabled-color: darken($widget-bg, 27%) !default;
+$tabstrip-border: rgba(0, 0, 0, .08) !default;
+$tabstrip-item-text: $link-text !default;
+$tabstrip-item-bg: transparent !default;
+$tabstrip-item-border: transparent !default;
+$tabstrip-item-hovered-text: $link-hover-text !default;
+$tabstrip-item-hovered-bg: transparent !default;
+$tabstrip-item-hovered-border: transparent !default;
+$tabstrip-item-selected-text: $base-text !default;
+$tabstrip-item-selected-bg: $panel-bg !default;
+$tabstrip-item-selected-border: $panel-border !default;
+$tabstrip-content-text: $panel-text !default;
+$tabstrip-content-bg: $panel-bg !default;
+$tabstrip-content-border: $panel-bg !default;
 
 @include exports('tabstrip/theme') {
 
     .k-tabstrip {
+        //border-color: $tabstrip-border;
 
         .k-item {
-            color: $link-text;
+            // border-color: $tabstrip-item-border;
+            color: $tabstrip-item-text;
+            //background-color: $tabstrip-item-bg;
             background-clip: padding-box;
 
             .k-ie11 &,
@@ -21,17 +31,22 @@ $tabstrip-disabled-color: darken($widget-bg, 27%) !default;
 
             &:hover,
             &.k-state-hover {
-                color: $link-hover-text;
+                // border-color: $tabstrip-item-hovered-border;
+                color: $tabstrip-item-hovered-text;
+                // background-color: $tabstrip-item-hovered-border;
             }
 
             &.k-state-active {
-                border-color: $panel-border;
-                color: $panel-text;
-                background-color: $panel-bg;
+                border-color: $tabstrip-item-selected-border;
+                color: $tabstrip-item-selected-text;
+                background-color: $tabstrip-item-selected-bg;
             }
         }
 
         > .k-content {
+            // border-color: $tabstrip-content-border;
+            // color: $tabstrip-content-text;
+            // background-color: $tabstrip-content-bg;
             background-clip: padding-box;
 
             .k-ie11 &,
@@ -47,28 +62,28 @@ $tabstrip-disabled-color: darken($widget-bg, 27%) !default;
     .k-tabstrip-top {
         > .k-tabstrip-items {
             .k-item.k-state-active {
-                border-bottom-color: $panel-bg;
+                border-bottom-color: $tabstrip-item-selected-bg;
             }
         }
     }
     .k-tabstrip-bottom {
         > .k-tabstrip-items {
             .k-item.k-state-active {
-                border-top-color: $panel-bg;
+                border-top-color: $tabstrip-item-selected-bg;
             }
         }
     }
     .k-tabstrip-left {
         > .k-tabstrip-items {
             .k-item.k-state-active {
-                border-right-color: $panel-bg;
+                border-right-color: $tabstrip-item-selected-bg;
             }
         }
     }
     .k-tabstrip-right {
         > .k-tabstrip-items {
             .k-item.k-state-active {
-                border-left-color: $panel-bg;
+                border-left-color: $tabstrip-item-selected-bg;
             }
         }
     }


### PR DESCRIPTION
Fixes #554.

* added scoped variables for tabstrip
* item- prefix for the items
* content- for the pane
* the lines for further customization are commented out.

Let's first finish the discussion in the related thread