### PR TITLE
fix(calendar): Add specificity to selected weekend day selector

### DIFF
--- a/scss/calendar/_layout.scss
+++ b/scss/calendar/_layout.scss
@@ -327,10 +327,6 @@ $calendar-navigation-width: 5em;
                 line-height: $calendar-cell-size;
                 padding: 0;
             }
-
-            .k-weekend {
-                background: none;
-            }
         }
 
         .k-calendar-weekdays {

--- a/scss/calendar/_theme.scss
+++ b/scss/calendar/_theme.scss
@@ -60,7 +60,7 @@
         }
 
         .k-alt,
-        .k-weekend {
+        .k-weekend:not(.k-calendar-infinite .k-weekend) {
             background: darken( $widget-bg, 5 );
         }
 
@@ -73,8 +73,7 @@
         }
 
         .k-state-selected,
-        .k-weekend.k-state-selected,
-        .k-calendar-monthview .k-content .k-weekend.k-state-selected {
+        .k-weekend.k-state-selected {
             @include appearance( selected-node );
 
             &.k-state-hover {

--- a/scss/calendar/_theme.scss
+++ b/scss/calendar/_theme.scss
@@ -73,7 +73,8 @@
         }
 
         .k-state-selected,
-        .k-weekend.k-state-selected {
+        .k-weekend.k-state-selected,
+        .k-calendar-monthview .k-content .k-weekend.k-state-selected {
             @include appearance( selected-node );
 
             &.k-state-hover {


### PR DESCRIPTION
This fixes a problem in NG Calendar: selected weekend day lacking background color.