### PR TITLE
fix(tabstrip): scroll buttons are not aligned in IE

### DIFF
--- a/scss/tabstrip/_layout.scss
+++ b/scss/tabstrip/_layout.scss
@@ -99,6 +99,14 @@
                 position: absolute;
                 right: 0;
             }
+
+            // Fixes kendo-theme-default#476
+            .k-ie11 & {
+                > .k-tabstrip-prev,
+                > .k-tabstrip-next {
+                    top: 0;
+                }
+            }
         }
 
     }


### PR DESCRIPTION
Fixes https://github.com/telerik/kendo-theme-default/issues/476