### PR TITLE
fix(grid): filter row operators appearance

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -216,6 +216,11 @@
                 }
             }
 
+            .k-filtercell-operator {
+                margin-left: 0;
+                margin-right: $cell-padding-y / 2;
+            }
+
             .k-dirty {
                 left: auto;
                 right: 0;
@@ -495,13 +500,12 @@
 
     .k-filtercell {
         width: auto;
-        display: block;
+        display: flex;
 
         > span,
         .k-filtercell-wrapper {
-            padding-right: calc( 2 * (#{$button-calc-size} + #{$cell-padding-y / 2}));
-            display: block;
-            position: relative;
+            display: flex;
+            flex: 1;
 
             > label {
                 vertical-align: middle;
@@ -511,16 +515,18 @@
 
         > span,
         .k-filtercell-operator {
-            > .k-button {
-                position: absolute;
-                top: 0;
-                right: 0;
+            > .k-button.k-clear-button-visible {
+                visibility: visible;
+            }
+
+            > .k-button:not(.k-clear-button-visible) {
+                visibility: hidden;
+                pointer-events: none;
             }
         }
 
-
-        > .k-operator-hidden {
-            padding-right: calc( #{$button-calc-size} + #{$cell-padding-y / 2});
+        .k-filtercell-operator {
+            margin-left: $cell-padding-y / 2;
         }
 
         .k-widget,
@@ -550,10 +556,8 @@
 
         .k-dropdown-operator {
             width: button-size();
+            display: inline-flex;
             flex: none;
-            position: absolute;
-            top: 0;
-            right: calc( #{$button-calc-size} + #{$cell-padding-y / 2} );
         }
 
         .k-dropdown-operator .k-input {


### PR DESCRIPTION
Related to: https://github.com/telerik/kendo-angular/issues/695

Respective change in the Grid filter row rendering: https://github.com/telerik/kendo-angular-grid/commit/7fce875c080df4ea98d231595847f94821b88e97

With this change we will use flex box and avoid using absolute positioning and calculated paddings for the filter row buttons  operators

!!! Don't merge it until https://github.com/telerik/kendo-angular-grid/pull/267 is merged