### PR TITLE
Common improvements

### DIFF
--- a/scss/common/_base.scss
+++ b/scss/common/_base.scss
@@ -49,13 +49,6 @@
         z-index: 10001;
     }
 
-    // hidden
-    .k-hidden {
-        // sass-lint:disable no-important
-        display: none !important;
-        // sass-lint:enable no-important
-    }
-
 
     // RTL
     .k-rtl {
@@ -127,6 +120,12 @@
         position: absolute;
         top: 0;
         right: 0;
+    }
+
+
+    // Hiding
+    .k-hidden {
+        display: none !important; // sass-lint:disable-block no-important
     }
 
 }

--- a/scss/common/_base.scss
+++ b/scss/common/_base.scss
@@ -125,7 +125,7 @@
 
     // Hiding
     .k-hidden {
-        display: none !important; // sass-lint:disable-block no-important
+        display: none !important; // sass-lint:disable-line no-important
     }
 
 }

--- a/scss/common/_base.scss
+++ b/scss/common/_base.scss
@@ -470,6 +470,10 @@
         border-bottom-color: transparent;
         background-color: transparent;
     }
+    .k-icon.k-i-loading::before,
+    .k-icon.k-i-loading::after {
+        content: "";
+    }
 
     .k-i-loading::before {
         margin-top: -.5em;

--- a/scss/common/_forms.scss
+++ b/scss/common/_forms.scss
@@ -89,6 +89,7 @@
         // TODO: improve wrapper overflow
         //overflow: hidden;
         cursor: default;
+        outline: 0;
 
         .k-input {
             padding: $input-padding-y $input-padding-x;

--- a/scss/common/_forms.scss
+++ b/scss/common/_forms.scss
@@ -220,6 +220,13 @@
         }
     }
 
+}
+
+
+
+
+@include exports( "stylehelpers/layout" ) {
+
     // Style helpers
     .k-textbox.k-space-left {
         padding-left: 1.9em;


### PR DESCRIPTION
Minor tweaks in the code, taken away from #369 for easier merging. The changes as follows: 

* extract style helpers in a separate "module"
* remove focus outline of pickers
* move `.k-hidden` few lines down
* ensure that the loading icon never has text by using a stronger selector (to cover `<span class="k-icon k-i-arrow-s k-i-loading" />` per say)