### PR TITLE
fix/tabstrip variable usage

### DIFF
--- a/scss/tabstrip/_theme.scss
+++ b/scss/tabstrip/_theme.scss
@@ -33,7 +33,7 @@ $tabstrip-content-border: $panel-bg !default;
             &.k-state-hover {
                 border-color: $tabstrip-item-hovered-border;
                 color: $tabstrip-item-hovered-text;
-                background-color: $tabstrip-item-hovered-border;
+                background-color: $tabstrip-item-hovered-bg;
             }
 
             &.k-state-active {
@@ -62,28 +62,28 @@ $tabstrip-content-border: $panel-bg !default;
     .k-tabstrip-top {
         > .k-tabstrip-items {
             .k-item.k-state-active {
-                border-bottom-color: $tabstrip-item-selected-bg;
+                border-bottom-color: $tabstrip-item-selected-border;
             }
         }
     }
     .k-tabstrip-bottom {
         > .k-tabstrip-items {
             .k-item.k-state-active {
-                border-top-color: $tabstrip-item-selected-bg;
+                border-top-color: $tabstrip-item-selected-border;
             }
         }
     }
     .k-tabstrip-left {
         > .k-tabstrip-items {
             .k-item.k-state-active {
-                border-right-color: $tabstrip-item-selected-bg;
+                border-right-color: $tabstrip-item-selected-border;
             }
         }
     }
     .k-tabstrip-right {
         > .k-tabstrip-items {
             .k-item.k-state-active {
-                border-left-color: $tabstrip-item-selected-bg;
+                border-left-color: $tabstrip-item-selected-border;
             }
         }
     }


### PR DESCRIPTION
Assigns the selected variable to tabstrip items which are active

@joneff I think there was a bug in the variables which you used for the colors