### PR TITLE
fix(editor): content of editor toolbar exceeds the size of the container

### DIFF
--- a/scss/editor/_layout.scss
+++ b/scss/editor/_layout.scss
@@ -63,6 +63,7 @@
         display: flex;
         flex-direction: row;
         justify-content: flex-start;
+        flex-wrap: wrap;
         position: relative;
 
         li {


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-theme-default/issues/371