### PR TITLE
fix(editor): Inconsistent Editor indent/outdent icons in RTL

### DIFF
--- a/scss/common/_icons.scss
+++ b/scss/common/_icons.scss
@@ -688,6 +688,11 @@
     .k-i-volume-mute::before { @extend .k-i-volume-off; }
     .k-i-forward-sm::before { @extend .k-i-arrow-double-60-right; }
 
+
+    // RTL icons
+    .k-rtl .k-i-indent-increase,
+    .k-rtl .k-i-indent-decrease { transform: scaleX(-1); }
+
     .k-sprite {
         display: inline-block;
         width: 16px;


### PR DESCRIPTION
Fixes https://github.com/telerik/kendo-theme-default/issues/155