### PR TITLE
fix(grid): Add negative widget offset margins to column menu icon in …

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -468,6 +468,8 @@
         }
         .k-header-column-menu {
             margin: 0;
+            margin-top: calc(#{$grid-form-component-offset} * -1);
+            margin-bottom: calc(#{$grid-form-component-offset} * -1);
         }
 
         .k-header > .k-link > .k-icon {


### PR DESCRIPTION
…header

Dealing with https://github.com/telerik/kendo-theme-default/issues/607 and https://github.com/telerik/kendo-theme-bootstrap/issues/218 (point 8)