### PR TITLE
fix(treeview): reduce spacing between checkbox and item text

### DIFF
--- a/scss/treeview/_layout.scss
+++ b/scss/treeview/_layout.scss
@@ -69,6 +69,9 @@
         .k-in .k-sprite {
             margin-right: $icon-spacing;
         }
+        .k-checkbox-label {
+            padding-left: $icon-size;
+        }
 
     }
 


### PR DESCRIPTION
related https://github.com/telerik/kendo-theme-bootstrap/issues/212