### PR TITLE
fix(maskedtextbox): allow wrapper width

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "cz-conventional-changelog": "^1.1.5",
     "ghooks": "^1.0.3",
     "glob": "^7.0.5",
+    "handlebars": "^4.0.10",
     "mime": "^1.3.4",
     "sass-lint": "^1.7.0",
     "sassdoc": "^2.1.20",

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -36,6 +36,11 @@
     .k-maskedtextbox {
         display: inline-flex;
         border-width: 0;
+
+        .k-textbox {
+            flex: 1 0 0;
+            min-width: 0;
+        }
     }
 
     .k-input,


### PR DESCRIPTION
as seen in telerik/kendo-angular#727

also introduced handlebars as a devdependency, due to an error in sassdoc with npm5

theme preview app is updated to allow testing of the maskedtextbox with the above

![image](https://user-images.githubusercontent.com/90405/28075971-c49950ce-6665-11e7-88b3-d4a70d5a5403.png)
