### PR TITLE
fix(spreadsheet): borders do not render in 2017.2.x

### DIFF
--- a/scss/spreadsheet/_layout.scss
+++ b/scss/spreadsheet/_layout.scss
@@ -419,6 +419,18 @@
         cursor: cell;
     }
 
+    // Border rendering
+    .k-spreadsheet-vborder {
+        position: absolute;
+        border-left-style: solid;
+        border-left-width: 1px;
+    }
+
+    .k-spreadsheet-hborder {
+        position: absolute;
+        border-top-style: solid;
+        border-top-width: 1px;
+    }
 }
 
 


### PR DESCRIPTION
The spreadsheet requires these classes after the 2017 R2 border rendering overhaul.

Reported in ticket 1118839 (with reproduction)