### PR TITLE
fix(grid): Add styles positioning the PDF export progress bar

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -580,7 +580,6 @@
             width: button-size();
             display: inline-flex;
             flex: none;
-            align-content: center;
         }
 
         .k-dropdown-operator .k-input {

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -580,6 +580,7 @@
             width: button-size();
             display: inline-flex;
             flex: none;
+            align-content: center;
         }
 
         .k-dropdown-operator .k-input {
@@ -758,6 +759,15 @@
         top: 50%;
         left: 50%;
         font-size: 64px;
+    }
+
+    .k-loading-pdf-progress {
+        margin: auto;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
     }
 
 }


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo-theme-default/issues/614 and 10. in https://github.com/telerik/kendo-theme-bootstrap/issues/218