### PR TITLE
fix(grid): Recalculate edit mode textbox width

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -8,6 +8,8 @@
 
     $edit-cell-input-space: calc(-#{$cell-padding} - #{$input-border-width}) !default;
 
+    $edit-cell-textbox-width: calc(100% + ((#{$cell-padding} + #{$input-border-width}) * 2)) !default;
+
     $grid-row-inner-height: add-two( $line-height-em, $cell-padding-y * 2 );
     // $grid-row-half-inner-height: add-two( $line-height-em / 2, $cell-padding-y );
     $grid-form-component-offset: calc( (#{$line-height-em} - #{button-size()}) / 2 ) !default;
@@ -256,6 +258,7 @@
         .k-dirty-cell {
             position: relative;
         }
+
         .k-dirty {
             border-width: 5px;
             left: 0;
@@ -264,7 +267,7 @@
 
         .k-grid-edit-row td > .k-textbox,
         .k-edit-cell > .k-textbox {
-            width: 100%;
+            width: $edit-cell-textbox-width;
         }
 
         .k-grid-edit-row td > .k-textbox,


### PR DESCRIPTION
Dealing with first comment in https://github.com/telerik/kendo-theme-bootstrap/issues/279, second point.