### PR TITLE
fix(grid): Change positioning of dirty cell TD in edit mode

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -660,6 +660,10 @@
             padding-top: 0;
             padding-bottom: 0;
         }
+
+        .k-dirty-cell {
+            position: static;
+        }
     }
     .k-grid-edit-row,
     .k-edit-cell {


### PR DESCRIPTION
Dealing with point 1 in the first comment of https://github.com/telerik/kendo-theme-bootstrap/issues/279