### PR TITLE
fix(grid): Tweak in-Grid edit mode widget width

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -266,7 +266,9 @@
         }
 
         .k-grid-edit-row td > .k-textbox,
-        .k-edit-cell > .k-textbox {
+        .k-grid-edit-row td > .k-widget,
+        .k-edit-cell > .k-textbox,
+        .k-edit-cell > .k-widget {
             width: $edit-cell-textbox-width;
         }
 
@@ -663,13 +665,6 @@
 
         .k-dirty-cell {
             position: static;
-        }
-    }
-    .k-grid-edit-row,
-    .k-edit-cell {
-        .k-widget,
-        .k-textbox {
-            width: 100%;
         }
     }
 

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -265,22 +265,6 @@
             right: auto;
         }
 
-        .k-grid-edit-row td > .k-textbox,
-        .k-grid-edit-row td > .k-widget,
-        .k-edit-cell > .k-textbox,
-        .k-edit-cell > .k-widget {
-            width: $edit-cell-textbox-width;
-        }
-
-        .k-grid-edit-row td > .k-textbox,
-        .k-grid-edit-row td > .k-widget,
-        .k-command-cell > .k-button,
-        .k-edit-cell > .k-textbox,
-        .k-edit-cell > .k-widget {
-            margin-top: $grid-form-component-offset;
-            margin-bottom: $grid-form-component-offset;
-            vertical-align: top;
-        }
     }
 
     // Toolbar
@@ -675,6 +659,23 @@
         > .text-box {
             margin-left: $edit-cell-input-space;
         }
+    }
+
+    .k-grid-edit-row td > .k-textbox,
+    .k-grid-edit-row td > .k-widget,
+    .k-edit-cell > .k-textbox,
+    .k-edit-cell > .k-widget {
+        width: $edit-cell-textbox-width;
+    }
+
+    .k-grid-edit-row td > .k-textbox,
+    .k-grid-edit-row td > .k-widget,
+    .k-command-cell > .k-button,
+    .k-edit-cell > .k-textbox,
+    .k-edit-cell > .k-widget {
+        margin-top: $grid-form-component-offset;
+        margin-bottom: $grid-form-component-offset;
+        vertical-align: top;
     }
 
     // Resize handle


### PR DESCRIPTION
Dealing with comment 2 of https://github.com/telerik/kendo-theme-bootstrap/issues/279