### PR TITLE
fix(gantt): move tasks to prevent overlapping dependency arrows

### DIFF
--- a/scss/gantt/_layout.scss
+++ b/scss/gantt/_layout.scss
@@ -460,7 +460,7 @@
         }
 
         .k-task-wrap {
-            margin: 0 -1.9em;
+            margin: 0 -26px;
         }
         .k-timeline .k-gantt-tasks tbody {
             text-align: left;

--- a/scss/gantt/_layout.scss
+++ b/scss/gantt/_layout.scss
@@ -459,7 +459,7 @@
             right: 0;
         }
 
-        .k-task-wrap {
+        .k-task-wrap:not(.k-milestone-wrap) {
             margin: 0 -26px;
         }
         .k-timeline .k-gantt-tasks tbody {

--- a/scss/gantt/_layout.scss
+++ b/scss/gantt/_layout.scss
@@ -196,7 +196,7 @@
         td::after { content: "\a0"; }
     }
     .k-task-wrap {
-        margin: 0 -1.5em;
+        margin: 0 -21px;
         padding: 5px 21px;
         display: inline-flex;
         flex-direction: row;


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-theme-bootstrap/issues/241