### PR TITLE
fix(grid): Switch dirty cell overflow to visible

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -648,7 +648,7 @@
         }
 
         .k-dirty-cell {
-            position: static;
+            overflow: visible;
         }
     }
 


### PR DESCRIPTION
Changes the overflow of the dirty cell in edit mode to visible to avoid cutting off the validation tooltip as described in comment 1 of https://github.com/telerik/kendo-theme-bootstrap/issues/279