### PR TITLE
fix(pivotgrid): Make grid cells non-wrapable

### DIFF
--- a/scss/pivotgrid/_layout.scss
+++ b/scss/pivotgrid/_layout.scss
@@ -2,6 +2,10 @@
 
     .k-pivot {
         position: relative;
+
+        .k-grid td {
+            white-space: nowrap;
+      }
     }
 
     .k-pivot-toolbar {


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo-theme-default/issues/633 and 1 in https://github.com/telerik/kendo-theme-bootstrap/issues/236