### PR TITLE
fix(menu): Add nowrap rule for Menu links

### DIFF
--- a/scss/menu/_layout.scss
+++ b/scss/menu/_layout.scss
@@ -28,6 +28,7 @@
             flex-direction: row;
             align-items: center;
             position: relative;
+            white-space: nowrap;
 
             .k-i-arrow-60-down {
                 margin-left: $icon-spacing;


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo-theme-default/issues/638 and 4 in https://github.com/telerik/kendo-theme-bootstrap/issues/236