### PR TITLE
fix(pivotgrid): Add missing styles for pseudo elements in PDF export

### DIFF
--- a/scss/common/_base.scss
+++ b/scss/common/_base.scss
@@ -102,6 +102,12 @@
         width: 14400px;
     }
 
+    //PDF export icons fix
+    .kendo-pdf-hide-pseudo-elements::before,
+    .kendo-pdf-hide-pseudo-elements::after {
+        // sass-lint:disable-block no-important
+        display: none !important;
+    }
 
     // Flipping
     .k-flip-h { transform: scaleX(-1); }


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo-theme-default/issues/642 and 3. of https://github.com/telerik/kendo-theme-bootstrap/issues/236