### PR TITLE
fix(pivotgrid): Remove flex from Grid container, add border-width

### DIFF
--- a/scss/pivotgrid/_layout.scss
+++ b/scss/pivotgrid/_layout.scss
@@ -7,11 +7,7 @@
             white-space: nowrap;
       }
         .k-grid-content {
-            flex: none;
-        }
-
-        .k-grid-content .k-grid-footer td {
-            border-bottom-width: 1px;
+            flex: 1 1 auto;
         }
     }
 

--- a/scss/pivotgrid/_layout.scss
+++ b/scss/pivotgrid/_layout.scss
@@ -6,6 +6,13 @@
         .k-grid td {
             white-space: nowrap;
       }
+        .k-grid-content {
+            flex: none;
+        }
+
+        .k-grid-content .k-grid-footer td {
+            border-bottom-width: 1px;
+        }
     }
 
     .k-pivot-toolbar {


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo-theme-default/issues/633