### PR TITLE
Fix grid header collapse

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -211,7 +211,6 @@
             .k-grid-footer {
                 padding-left: 17px;
                 padding-right: 0;
-                flex: 0 0 auto;
             }
 
             .k-grid-header {
@@ -386,6 +385,7 @@
     }
     .k-grid-header,
     .k-grid-footer {
+        flex: 0 0 auto;
         padding-right: 17px;
         border-width: 0;
         border-style: solid;

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -386,6 +386,7 @@
     .k-grid-header,
     .k-grid-footer {
         flex: 0 0 auto;
+        display: flex;
         padding-right: 17px;
         border-width: 0;
         border-style: solid;
@@ -711,6 +712,7 @@
     .k-grid-content-locked,
     .k-grid-footer-locked,
     .k-grid-header-locked {
+        flex: 1 0 auto;
         display: inline-block;
         vertical-align: top;
         overflow: hidden;
@@ -719,9 +721,10 @@
         border-width: 0 1px 0 0;
     }
 
-    .k-grid-content-locked+.k-grid-content,
-    .k-grid-footer-locked+.k-grid-footer-wrap,
-    .k-grid-header-locked+.k-grid-header-wrap {
+    .k-grid-content,
+    .k-grid-footer-wrap,
+    .k-grid-header-wrap {
+        flex: 1 1 auto;
         display: inline-block;
         vertical-align: top;
     }


### PR DESCRIPTION
Fixes header collapsing when `overflow:hidden` is applied to it, and starts using flexbox for locked column layout calculation.

See telerik/kendo-angular#709