### PR TITLE
fix(grid): use flexbox chrome only when scrolling

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -383,10 +383,10 @@
         position: relative;
         overflow: hidden;
     }
+
     .k-grid-header,
     .k-grid-footer {
         flex: 0 0 auto;
-        display: flex;
         padding-right: 17px;
         border-width: 0;
         border-style: solid;
@@ -395,6 +395,11 @@
         table {
             table-layout: fixed;
         }
+    }
+
+    div.k-grid-header,
+    div.k-grid-footer {
+        display: flex;
     }
 
     .k-grid-header {


### PR DESCRIPTION
Fixes a regression after https://github.com/telerik/kendo-theme-default/commit/e6ac33596b3b47b3a4a4ad1b089efd3d8dc4ac7d, as setting `display: flex` to `thead` and `tfoot` does not work well.