### PR TITLE
fix(editor): prevent resize handler to overlap scrolling arrow

### DIFF
--- a/scss/editor/_layout.scss
+++ b/scss/editor/_layout.scss
@@ -135,6 +135,9 @@
         border-color: inherit;
         outline: 0;
     }
+    &.k-resizable .k-editable-area {
+        padding: $input-padding-y $input-padding-y 16px;
+    }
 
 
     $ct-cell-size: 20px;


### PR DESCRIPTION
related https://github.com/telerik/kendo-ui-core/issues/3445
related https://github.com/telerik/kendo/pull/7418