### PR TITLE
Ripple effect, floating label, checkbox / radiobutton / math improvements

### DIFF
--- a/scss/all.scss
+++ b/scss/all.scss
@@ -3,6 +3,7 @@
 
 // Dependencies
 @import "common/all";
+@import "ripple";
 @import "popup";
 
 

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -114,8 +114,8 @@
             left: $checkbox-size / 2;
             right: auto;
             bottom: auto;
-            width: $checkbox-size * 2;
-            height: $checkbox-size * 2;
+            width: $checkbox-size * 5 / 2;
+            height: $checkbox-size * 5 / 2;
             transform: translate(-50%, -50%);
             border-radius: 50%;
         }

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -5,6 +5,7 @@
     $textbox-shadow: 0 2px 2px 1px rgba(0, 0, 0, .06) !default;
     $fieldset-margin: 30px;
 
+    $textbox-line-height: $form-line-height-em !default;
     // TODO: legacy, consider switching to 100%
     $textbox-default-width: 12.4em !default;
 
@@ -19,7 +20,7 @@
         border-style: solid;
         outline: 0;
         font: inherit;
-        line-height: $form-line-height;
+        line-height: $textbox-line-height;
         display: inline-flex;
         vertical-align: middle;
         position: relative;
@@ -53,7 +54,7 @@
 
     .k-textbox,
     .k-input.k-textbox {
-        height: calc(#{$form-line-height-em} + (#{$input-padding-y} * 2) + (#{$input-border-width} * 2));
+        height: calc(#{$textbox-line-height} + (#{$input-padding-y} * 2) + (#{$input-border-width} * 2));
     }
 
     .k-textarea {
@@ -109,8 +110,9 @@
 
 
     // input container / floating label
-    $floating-label-height: 24px !default;
     $floating-label-transition: .4s ease !default;
+    $floating-label-scale: .75 !default;
+    $floating-label-height: $textbox-line-height * $floating-label-scale;
 
     .k-input-container {
         position: relative;
@@ -120,19 +122,22 @@
 
         > label {
             position: absolute;
-            top: add-two($floating-label-height, $input-border-width);
+            top: add-three($floating-label-height, $input-border-width, $input-padding-y);
             left: add-two($input-padding-x, $input-border-width);
-            line-height: add-two($form-line-height-em, $input-padding-y * 2);
+            line-height: $textbox-line-height;
             cursor: text;
-            transition: transform $floating-label-transition, color $floating-label-transition;
+            transition: transform $floating-label-transition, color $floating-label-transition, line-height $floating-label-transition;
         }
 
         > .k-textbox:focus ~ label,
         > .k-textbox:valid ~ label {
-            $scale: .75;
-            $top-offset: add-two($floating-label-height, $input-border-width, -1);
-            $left-scale: add-three($input-padding-x, $input-border-width, ((1 - $scale) * 100% / 2), -1);
-            transform: translate( $left-scale, $top-offset ) scale($scale);
+            // persist alignment after scaling
+            $half-scale-percent: ((1 - $floating-label-scale) * 100% / 2);
+
+            // transform position to top-left corner of input-container
+            $top-offset: add-three($textbox-line-height, $input-padding-y, $half-scale-percent, -$floating-label-scale);
+            $left-scale: add-three($input-padding-x, $input-border-width, $half-scale-percent, -1);
+            transform: translate( $left-scale, $top-offset ) scale($floating-label-scale);
         }
     }
 

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -95,6 +95,8 @@
     }
 
     $checkbox-size: $icon-size !default;
+    $checkbox-border-width: 1px !default;
+    $checkbox-line-height: 1 !default;
 
     .k-checkbox-label,
     .k-radio-label {
@@ -124,7 +126,7 @@
         text-align: center;
         font-size: $checkbox-size;
         line-height: $line-height * .8;
-        border-width: 1px;
+        border-width: $checkbox-border-width;
         border-style: solid;
         display: inline-flex;
         align-items: center;
@@ -160,7 +162,7 @@
     }
 
     .k-checkbox:disabled + .k-checkbox-label::before {
-        border-width: 1px;
+        border-width: $checkbox-border-width;
         border-style: solid;
     }
 
@@ -172,7 +174,7 @@
         left: 0;
         top: 0;
         border-radius: $radio-radius;
-        border-width: 1px;
+        border-width: $checkbox-border-width;
         border-style: solid;
         padding: 0;
     }

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -106,7 +106,26 @@
         cursor: pointer;
         display: inline-flex;
         align-items: baseline;
-        line-height: 1;
+        line-height: $checkbox-line-height;
+
+        .k-ripple {
+            top: $checkbox-size / 2;
+            left: $checkbox-size / 2;
+            right: auto;
+            bottom: auto;
+            width: $checkbox-size * 2;
+            height: $checkbox-size * 2;
+            transform: translate(-50%, -50%);
+            border-radius: 50%;
+        }
+
+        .k-ripple-blob {
+            // TODO: enhance ripple to yield positioning logic instead of using !important
+            top: 50% !important;
+            left: 50% !important;
+            width: 200% !important;
+            height: 200% !important;
+        }
     }
 
     .k-checkbox-label::before,

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -5,12 +5,15 @@
     $textbox-shadow: 0 2px 2px 1px rgba(0, 0, 0, .06) !default;
     $fieldset-margin: 30px;
 
+    // TODO: legacy, consider switching to 100%
+    $textbox-default-width: 12.4em !default;
+
     .k-textbox,
     .k-input.k-textbox,
     .k-textarea {
         @include border-radius();
         padding: $input-padding-y $input-padding-x;
-        width: 12.4em;
+        width: $textbox-default-width;
         box-sizing: border-box;
         border-width: $input-border-width;
         border-style: solid;
@@ -21,6 +24,31 @@
         vertical-align: middle;
         position: relative;
         -webkit-appearance: none;
+
+        + .k-input-bar {
+            position: relative;
+            display: block;
+            width: $textbox-default-width;
+            z-index: 2;
+
+            &::after {
+                content: '';
+                position: absolute;
+                bottom: 0;
+                left: 0;
+                right: 0;
+                height: 2 * $input-border-width;
+                margin: auto;
+                opacity: 0;
+                transform: scaleX(.5);
+                transition: transform .3s;
+            }
+        }
+
+        &:focus + .k-input-bar::after {
+            opacity: 1;
+            transform: scaleX(1);
+        }
     }
 
     .k-textbox,
@@ -79,6 +107,39 @@
         }
     }
 
+
+    // input container / floating label
+    $floating-label-padding: 7px !default;
+
+    .k-input-container {
+        position: relative;
+        padding-top: $floating-label-padding * 2;
+        display: inline-flex;
+        flex-direction: column;
+
+        > label {
+            position: absolute;
+            left: add-two($input-padding-x, $input-border-width);
+            top: add-three($floating-label-padding, $input-padding-y, $input-border-width);
+            line-height: $form-line-height;
+            transition: all .2s ease;
+        }
+
+        > .k-textbox:focus ~ label,
+        > .k-textbox:valid ~ label {
+            font-size: 12px;
+            top: 0;
+            left: 0;
+        }
+    }
+
+
+    // checkbox / radio button
+    $checkbox-size: $icon-size !default;
+    $checkbox-border-width: 1px !default;
+    $checkbox-line-height: 1 !default;
+    $checkbox-indeterminate-style: square !default;
+
     .k-checkbox,
     .k-radio {
         position: absolute;
@@ -93,11 +154,6 @@
     .k-checkbox:disabled + .k-checkbox-label {
         @include disabled;
     }
-
-    $checkbox-size: $icon-size !default;
-    $checkbox-border-width: 1px !default;
-    $checkbox-line-height: 1 !default;
-    $checkbox-indeterminate-style: square !default;
 
     .k-checkbox-label,
     .k-radio-label {

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -130,7 +130,9 @@
     }
 
     .k-checkbox-label::before,
-    .k-radio-label::before {
+    .k-checkbox-label::after,
+    .k-radio-label::before,
+    .k-radio-label::after {
         font-family: "WebComponentsIcons";
         box-sizing: border-box;
     }
@@ -150,91 +152,95 @@
         border-style: solid;
         display: inline-flex;
         align-items: center;
+
+        .k-checkbox:disabled + & {
+            border-width: $checkbox-border-width;
+            border-style: solid;
+        }
     }
 
-    .k-checkbox:indeterminate + .k-checkbox-label::after {
-        box-sizing: border-box;
-        content: "";
+    .k-checkbox-label::after {
+        content: "\e118";
         position: absolute;
+        top: 0;
+        left: 0;
+        width: $checkbox-size;
+        height: $checkbox-size;
+        text-align: center;
+        display: inline-flex;
+        align-items: center;
+        border: $checkbox-border-width solid transparent;
+        overflow: hidden;
+        max-width: 0;
 
-        @if $checkbox-indeterminate-style == 'dash' {
-            $height: $checkbox-size / 10;
-            height: $height;
-            top: ( ( $checkbox-size - $height ) / 2 );
+        .k-checkbox:checked + & {
+            max-width: $checkbox-size;
+        }
 
-            width: $checkbox-size - 2 * $checkbox-border-width;
-            left: $checkbox-border-width;
-        } @else {
+        .k-checkbox:indeterminate + & {
+            max-width: $checkbox-size;
+            box-sizing: border-box;
+            content: "";
+            position: absolute;
+
+            @if $checkbox-indeterminate-style == 'dash' {
+                $height: $checkbox-size / 10;
+                border-width: 0;
+                height: $height;
+                top: ( ( $checkbox-size - $height ) / 2 );
+                width: $checkbox-size - 2 * $checkbox-border-width;
+                left: $checkbox-border-width;
+            } @else {
+                width: $checkbox-size / 2;
+                height: $checkbox-size / 2;
+                top: $checkbox-size / 4;
+                left: $checkbox-size / 4;
+            }
+        }
+
+        .k-checkbox:disabled + & {
+            cursor: default;
+            opacity: .5;
+        }
+    }
+
+    .k-radio-label {
+        &::before {
+            content: "";
+            width: $checkbox-size;
+            height: $checkbox-size;
+            position: absolute;
+            left: 0;
+            top: 0;
+            border-radius: $radio-radius;
+            border-width: $checkbox-border-width;
+            border-style: solid;
+            padding: 0;
+        }
+
+        &::after {
+            content: "";
+            position: absolute;
+            border-radius: 50%;
             width: $checkbox-size / 2;
             height: $checkbox-size / 2;
             top: $checkbox-size / 4;
             left: $checkbox-size / 4;
+            transform: scale(0);
+
+            .k-radio:checked + & {
+                transform: scale(1);
+            }
+
+            .k-radio:disabled + & {
+                opacity: .5;
+            }
         }
-    }
 
-    .k-checkbox:indeterminate:disabled + .k-checkbox-label::after {
-        opacity: .5;
-    }
-
-    .k-checkbox:disabled + .k-checkbox-label,
-    .k-checkbox:checked:disabled + .k-checkbox-label {
-        cursor: default;
-    }
-
-    .k-checkbox:checked + .k-checkbox-label::before {
-        content: "\e118";
-        border-width: 0;
-    }
-
-    .k-checkbox:checked:disabled + .k-checkbox-label::before {
-        content: "\e118";
-        opacity: .5;
-    }
-
-    .k-checkbox:disabled + .k-checkbox-label::before {
-        border-width: $checkbox-border-width;
-        border-style: solid;
-    }
-
-    .k-radio-label::before {
-        content: "";
-        width: $checkbox-size;
-        height: $checkbox-size;
-        position: absolute;
-        left: 0;
-        top: 0;
-        border-radius: $radio-radius;
-        border-width: $checkbox-border-width;
-        border-style: solid;
-        padding: 0;
-    }
-
-    .k-radio-label::after {
-        content: "";
-        position: absolute;
-        border-radius: 50%;
-        width: $checkbox-size / 2;
-        height: $checkbox-size / 2;
-        top: $checkbox-size / 4;
-        left: $checkbox-size / 4;
-        transform: scale(0);
-    }
-
-    .k-radio:checked + .k-radio-label::after {
-        transform: scale(1);
-    }
-
-    .k-radio:disabled + .k-radio-label {
-        cursor: auto;
-    }
-
-    .k-radio:disabled + .k-radio-label,
-    .k-radio:checked:disabled + .k-radio-label {
-        cursor: default;
-    }
-
-    .k-radio:checked:disabled + .k-radio-label::before {
-        opacity: .5;
+        .k-radio:disabled + &,
+        .k-radio:checked:disabled + & {
+            cursor: default;
+        }
     }
 
     .k-fieldset {

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -201,6 +201,7 @@
         box-sizing: border-box;
     }
 
+    // container box
     .k-checkbox-label::before {
         @include border-radius( $checkbox-radius );
         content: "";
@@ -223,6 +224,7 @@
         }
     }
 
+    // tick or indeterminate state
     .k-checkbox-label::after {
         content: "\e118";
         position: absolute;
@@ -269,6 +271,7 @@
     }
 
     .k-radio-label {
+        // container circle
         &::before {
             content: "";
             width: $checkbox-size;
@@ -282,6 +285,7 @@
             padding: 0;
         }
 
+        // checked state
         &::after {
             content: "";
             position: absolute;

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -97,6 +97,7 @@
     $checkbox-size: $icon-size !default;
     $checkbox-border-width: 1px !default;
     $checkbox-line-height: 1 !default;
+    $checkbox-indeterminate-style: square !default;
 
     .k-checkbox-label,
     .k-radio-label {
@@ -155,10 +156,20 @@
         box-sizing: border-box;
         content: "";
         position: absolute;
-        width: $checkbox-size / 2;
-        height: $checkbox-size / 2;
-        top: $checkbox-size / 4;
-        left: $checkbox-size / 4;
+
+        @if $checkbox-indeterminate-style == 'dash' {
+            $height: $checkbox-size / 10;
+            height: $height;
+            top: ( ( $checkbox-size - $height ) / 2 );
+
+            width: $checkbox-size - 2 * $checkbox-border-width;
+            left: $checkbox-border-width;
+        } @else {
+            width: $checkbox-size / 2;
+            height: $checkbox-size / 2;
+            top: $checkbox-size / 4;
+            left: $checkbox-size / 4;
+        }
     }
 
     .k-checkbox:indeterminate:disabled + .k-checkbox-label::after {

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -152,10 +152,6 @@
         border-width: 0;
     }
 
-    .k-checkbox:checked + .k-checkbox-label:hover::before {
-        border-width: 1px;
-    }
-
     .k-checkbox:checked:disabled + .k-checkbox-label::before {
         content: "\e118";
         opacity: .5;

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -209,14 +209,19 @@
         padding: 0;
     }
 
-    .k-radio:checked + .k-radio-label::after {
+    .k-radio-label::after {
         content: "";
         position: absolute;
+        border-radius: 50%;
         width: $checkbox-size / 2;
         height: $checkbox-size / 2;
         top: $checkbox-size / 4;
         left: $checkbox-size / 4;
-        border-radius: 50%;
+        transform: scale(0);
+    }
+
+    .k-radio:checked + .k-radio-label::after {
+        transform: scale(1);
     }
 
     .k-radio:disabled + .k-radio-label {

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -109,27 +109,30 @@
 
 
     // input container / floating label
-    $floating-label-padding: 7px !default;
+    $floating-label-height: 24px !default;
+    $floating-label-transition: .4s ease !default;
 
     .k-input-container {
         position: relative;
-        padding-top: $floating-label-padding * 2;
+        padding-top: $floating-label-height;
         display: inline-flex;
         flex-direction: column;
 
         > label {
             position: absolute;
+            top: add-two($floating-label-height, $input-border-width);
             left: add-two($input-padding-x, $input-border-width);
-            top: add-three($floating-label-padding, $input-padding-y, $input-border-width);
-            line-height: $form-line-height;
-            transition: all .2s ease;
+            line-height: add-two($form-line-height-em, $input-padding-y * 2);
+            cursor: text;
+            transition: transform $floating-label-transition, color $floating-label-transition;
         }
 
         > .k-textbox:focus ~ label,
         > .k-textbox:valid ~ label {
-            font-size: 12px;
-            top: 0;
-            left: 0;
+            $scale: .75;
+            $top-offset: add-two($floating-label-height, $input-border-width, -1);
+            $left-scale: add-three($input-padding-x, $input-border-width, ((1 - $scale) * 100% / 2), -1);
+            transform: translate( $left-scale, $top-offset ) scale($scale);
         }
     }
 

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -94,10 +94,12 @@
         @include disabled;
     }
 
+    $checkbox-size: $icon-size !default;
+
     .k-checkbox-label,
     .k-radio-label {
         position: relative;
-        padding-left: add-two($icon-size, ($padding-x-lg / 2));
+        padding-left: add-two($checkbox-size, ($padding-x-lg / 2));
         vertical-align: text-top;
         cursor: pointer;
         display: inline-flex;
@@ -117,10 +119,10 @@
         position: absolute;
         top: 0;
         left: 0;
-        width: $icon-size;
-        height: $icon-size;
+        width: $checkbox-size;
+        height: $checkbox-size;
         text-align: center;
-        font-size: $icon-size;
+        font-size: $checkbox-size;
         line-height: $line-height * .8;
         border-width: 1px;
         border-style: solid;
@@ -132,10 +134,10 @@
         box-sizing: border-box;
         content: "";
         position: absolute;
-        width: $icon-size / 2;
-        height: $icon-size / 2;
-        top: $icon-size / 4;
-        left: $icon-size / 4;
+        width: $checkbox-size / 2;
+        height: $checkbox-size / 2;
+        top: $checkbox-size / 4;
+        left: $checkbox-size / 4;
     }
 
     .k-checkbox:indeterminate:disabled + .k-checkbox-label::after {
@@ -164,8 +166,8 @@
 
     .k-radio-label::before {
         content: "";
-        width: $icon-size;
-        height: $icon-size;
+        width: $checkbox-size;
+        height: $checkbox-size;
         position: absolute;
         left: 0;
         top: 0;
@@ -178,10 +180,10 @@
     .k-radio:checked + .k-radio-label::after {
         content: "";
         position: absolute;
-        width: $icon-size / 2;
-        height: $icon-size / 2;
-        top: $icon-size / 4;
-        left: $icon-size / 4;
+        width: $checkbox-size / 2;
+        height: $checkbox-size / 2;
+        top: $checkbox-size / 4;
+        left: $checkbox-size / 4;
         border-radius: 50%;
     }
 

--- a/scss/input/_theme.scss
+++ b/scss/input/_theme.scss
@@ -73,6 +73,9 @@
 
     $checkbox-bg: $input-bg !default;
     $checkbox-border: $input-border !default;
+
+    $checkbox-hovered-border: $input-hovered-border !default;
+
     $checkbox-checked-bg: $accent !default;
     $checkbox-checked-border: $accent !default;
     $checkbox-checked-text: $accent-contrast !default;
@@ -113,6 +116,11 @@
 
     .k-checkbox-label::after {
         color: $checkbox-checked-text;
+    }
+
+    .k-checkbox-label:hover::before,
+    .k-checkbox:checked + .k-checkbox-label:hover::before {
+        border-color: $checkbox-hovered-border;
     }
 
     .k-checkbox:checked + .k-checkbox-label::after,

--- a/scss/input/_theme.scss
+++ b/scss/input/_theme.scss
@@ -79,8 +79,8 @@
 
     $checkbox-focused-shadow: 0 0 0 2px rgba(0, 0, 0, .06) !default;
     $checkbox-focused-checked-shadow: 0 0 0 2px rgba($accent, .3) !default;
-    $checkbox-focused-border: $input-hovered-border;
-    $checkbox-focused-checked-border: $accent;
+    $checkbox-focused-border: $input-hovered-border !default;
+    $checkbox-focused-checked-border: $accent !default;
 
     .k-radio + .k-radio-label {
         &::before {

--- a/scss/input/_theme.scss
+++ b/scss/input/_theme.scss
@@ -104,14 +104,18 @@
     .k-checkbox-label::before {
         background-color: $checkbox-bg;
         border-color: $checkbox-border;
+
+        .k-checkbox:checked + & {
+            background-color: $checkbox-checked-bg;
+            border-color: $checkbox-checked-border;
+        }
     }
 
-    .k-checkbox:checked + .k-checkbox-label::before {
-        background-color: $checkbox-checked-bg;
-        border-color: $checkbox-checked-border;
+    .k-checkbox-label::after {
         color: $checkbox-checked-text;
     }
 
+    .k-checkbox:checked + .k-checkbox-label::after,
     .k-checkbox:indeterminate + .k-checkbox-label::after {
         background-color: $checkbox-checked-bg;
         border-color: $checkbox-checked-border;

--- a/scss/input/_theme.scss
+++ b/scss/input/_theme.scss
@@ -1,19 +1,5 @@
 @include exports('input/theme') {
 
-    $radio-border: $input-border !default;
-    $radio-bg: $input-bg !default;
-    $radio-checked-bg: $accent !default;
-    $radio-checked-text: $accent-contrast !default;
-
-    $checkbox-bg: $input-bg !default;
-    $checkbox-border: $input-border !default;
-    $checkbox-checked-bg: $accent !default;
-    $checkbox-checked-border: $accent !default;
-    $checkbox-checked-text: $accent-contrast !default;
-
-    $focused-shadow: 0 0 0 2px rgba(0, 0, 0, .06) !default;
-    $focused-checked-shadow: 0 0 0 2px rgba($accent, .3) !default;
-
     .k-textbox,
     .k-input.k-textbox,
     .k-textarea {
@@ -74,6 +60,24 @@
             color: rgba($input-text, .5);
         }
     }
+
+}
+
+@include exports('input/checkbox-radiobutton') {
+
+    $radio-border: $input-border !default;
+    $radio-bg: $input-bg !default;
+    $radio-checked-bg: $accent !default;
+    $radio-checked-text: $accent-contrast !default;
+
+    $checkbox-bg: $input-bg !default;
+    $checkbox-border: $input-border !default;
+    $checkbox-checked-bg: $accent !default;
+    $checkbox-checked-border: $accent !default;
+    $checkbox-checked-text: $accent-contrast !default;
+
+    $focused-shadow: 0 0 0 2px rgba(0, 0, 0, .06) !default;
+    $focused-checked-shadow: 0 0 0 2px rgba($accent, .3) !default;
 
     .k-radio + .k-radio-label {
         &::before {

--- a/scss/input/_theme.scss
+++ b/scss/input/_theme.scss
@@ -63,11 +63,12 @@
 
 }
 
-@include exports('input/checkbox-radiobutton') {
+@include exports('input/theme/checkbox-radiobutton') {
 
     $radio-border: $input-border !default;
     $radio-bg: $input-bg !default;
     $radio-checked-bg: $accent !default;
+    $radio-checked-border: transparent !default;
     $radio-checked-text: $accent-contrast !default;
 
     $checkbox-bg: $input-bg !default;
@@ -76,8 +77,10 @@
     $checkbox-checked-border: $accent !default;
     $checkbox-checked-text: $accent-contrast !default;
 
-    $focused-shadow: 0 0 0 2px rgba(0, 0, 0, .06) !default;
-    $focused-checked-shadow: 0 0 0 2px rgba($accent, .3) !default;
+    $checkbox-focused-shadow: 0 0 0 2px rgba(0, 0, 0, .06) !default;
+    $checkbox-focused-checked-shadow: 0 0 0 2px rgba($accent, .3) !default;
+    $checkbox-focused-border: $input-hovered-border;
+    $checkbox-focused-checked-border: $accent;
 
     .k-radio + .k-radio-label {
         &::before {
@@ -89,7 +92,7 @@
     .k-radio:checked + .k-radio-label {
         &::before {
             background-color: $radio-checked-bg;
-            border-color: transparent;
+            border-color: $radio-checked-border;
             box-shadow: 0 0 1px 0 $radio-checked-bg inset;
         }
 
@@ -116,15 +119,21 @@
 
     .k-checkbox:focus + .k-checkbox-label::before,
     .k-radio:focus + .k-radio-label::before {
-        box-shadow: $focused-shadow;
-        border-color: $input-hovered-border;
+        box-shadow: $checkbox-focused-shadow;
+        border-color: $checkbox-focused-border;
     }
 
     .k-checkbox:focus:checked + .k-checkbox-label::before,
     .k-radio:focus:checked + .k-radio-label::before {
-        box-shadow: $focused-checked-shadow;
-        border-color: $accent;
+        box-shadow: $checkbox-focused-checked-shadow;
+        border-color: $checkbox-focused-checked-border;
     }
+
+}
+
+@include exports('input/theme/form-styles') {
+
+    $form-fieldset-legend-text: darken($text-color, 13%) !default;
 
     fieldset {
         border-color: $input-border;
@@ -133,8 +142,6 @@
     fieldset legend {
         color: $header-text;
     }
-
-    $form-fieldset-legend-text: darken($text-color, 13%) !default;
 
     .k-form,
     .k-form-inline {

--- a/scss/input/_theme.scss
+++ b/scss/input/_theme.scss
@@ -7,15 +7,12 @@
 
     $checkbox-bg: $input-bg !default;
     $checkbox-border: $input-border !default;
-    $checkbox-hovered-bg: $input-bg !default;
-    $checkbox-hovered-border: $input-hovered-border !default;
-    $checkbox-hovered-text: $accent !default;
     $checkbox-checked-bg: $accent !default;
     $checkbox-checked-border: $accent !default;
     $checkbox-checked-text: $accent-contrast !default;
 
-    $focused-checkbox-shadow: 0 3px 3px 1px rgba(0, 0, 0, .06) !default;
-    $focused-checked-shadow: 0 3px 4px rgba($accent, .3) !default;
+    $focused-shadow: 0 0 0 2px rgba(0, 0, 0, .06) !default;
+    $focused-checked-shadow: 0 0 0 2px rgba($accent, .3) !default;
 
     .k-textbox,
     .k-input.k-textbox,
@@ -102,21 +99,10 @@
         border-color: $checkbox-border;
     }
 
-    .k-checkbox-label:hover::before {
-        border-color: $checkbox-hovered-border;
-    }
-
     .k-checkbox:checked + .k-checkbox-label::before {
         background-color: $checkbox-checked-bg;
         border-color: $checkbox-checked-border;
         color: $checkbox-checked-text;
-    }
-
-    .k-checkbox-label:hover::before,
-    .k-checkbox:checked + .k-checkbox-label:hover::before {
-        background-color: $checkbox-hovered-bg;
-        border-color: $checkbox-hovered-border;
-        color: $checkbox-hovered-text;
     }
 
     .k-checkbox:indeterminate + .k-checkbox-label::after {
@@ -126,7 +112,7 @@
 
     .k-checkbox:focus + .k-checkbox-label::before,
     .k-radio:focus + .k-radio-label::before {
-        box-shadow: $focused-checkbox-shadow;
+        box-shadow: $focused-shadow;
         border-color: $input-hovered-border;
     }
 

--- a/scss/mixins/core/_math.scss
+++ b/scss/mixins/core/_math.scss
@@ -6,6 +6,15 @@
     $_one: $multiplier * $one;
     $_two: $multiplier * $two;
 
+    // if either is zero
+    @if $_one == 0 {
+        @return $_two;
+    }
+
+    @if $_two == 0 {
+        @return $_one;
+    }
+
     // if all units are same type
     @if $_unit-1 == $_unit-2 {
         @return $_one + $_two;
@@ -25,6 +34,20 @@
     $_one: $multiplier * $one;
     $_two: $multiplier * $two;
     $_three: $multiplier * $three;
+
+    // pass to add-two if any component is zero
+    @if $_one == 0 {
+        @return add-two($two, $three, $multiplier);
+    }
+
+    @if $_two == 0 {
+        @return add-two($one, $three, $multiplier);
+    }
+
+    @if $_three == 0 {
+        @return add-two($one, $two, $multiplier);
+    }
+
 
     // if all units are same type
     @if $_unit-1 == $_unit-2 == $_unit-3 {

--- a/scss/ripple.scss
+++ b/scss/ripple.scss
@@ -1,0 +1,10 @@
+@import "variables";
+@import "mixins";
+
+
+// Dependencies
+
+
+// Component
+@import "ripple/layout";
+@import "ripple/theme";

--- a/scss/ripple/_layout.scss
+++ b/scss/ripple/_layout.scss
@@ -6,6 +6,7 @@
         left: 0;
         right: 0;
         bottom: 0;
+        z-index: 1;
         overflow: hidden;
         pointer-events: none;
     }

--- a/scss/ripple/_layout.scss
+++ b/scss/ripple/_layout.scss
@@ -1,0 +1,28 @@
+@include exports( 'ripple/layout' ) {
+
+    .k-ripple {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        overflow: hidden;
+        pointer-events: none;
+    }
+
+    .k-ripple-blob {
+        pointer-events: none;
+        position: absolute;
+        border-radius: 50%;
+        opacity: 0;
+        padding: 0;
+        transform: translate(-50%, -50%) scale(0);
+        transition: opacity 100ms linear, transform 500ms cubic-bezier(.4, 0, .2, 1);
+        background-color: rgba(0, 0, 0, .1);
+
+        .k-primary & {
+            background-color: rgba(255, 255, 255, .2);
+        }
+    }
+
+}

--- a/scss/ripple/_layout.scss
+++ b/scss/ripple/_layout.scss
@@ -24,6 +24,10 @@
         .k-primary & {
             opacity: .2;
         }
+
+        .k-primary.k-flat & {
+            opacity: 1;
+        }
     }
 
 }

--- a/scss/ripple/_layout.scss
+++ b/scss/ripple/_layout.scss
@@ -15,14 +15,14 @@
         pointer-events: none;
         position: absolute;
         border-radius: 50%;
-        opacity: 0;
         padding: 0;
         transform: translate(-50%, -50%) scale(0);
         transition: opacity 100ms linear, transform 500ms cubic-bezier(.4, 0, .2, 1);
-        background-color: rgba(0, 0, 0, .1);
+        opacity: .1;
+        background-color: currentColor;
 
         .k-primary & {
-            background-color: rgba(255, 255, 255, .2);
+            opacity: .2;
         }
     }
 


### PR DESCRIPTION
Some features that are necessary for the Material theme. It is all nested in one PR due to the intertwined features (ripple effects, input sizing). Goes hand-in-hand with the [`checkbox-styling` branch in theme-material](https://github.com/telerik/kendo-theme-material/tree/checkbox-styling).

* `add-two` and `add-three` are fixed for zero units (`calc( 0 + 2px )` is invalid)
* adds ripple effect styles for all themes
* checkboxes and radio buttons now use `::before` for their box, and `::after` for the indeterminate/checked states. This allows the checked state to be animated, and for the styling to be consistent. There are also variables that allow [configuration of the checkbox size, and the style of the indeterminate state](https://github.com/telerik/kendo-theme-default/blob/material-checkbox/scss/input/_layout.scss#L146-L149) (dash or square).
* these commits [imports the floating label styles from material](https://github.com/telerik/kendo-theme-material/pull/3) and makes it available in all themes.

@mvgmvg I had to [revert the checkbox hover commit](https://github.com/telerik/kendo-theme-default/commit/bae6fb993339f5b7177b0f3c06337788e3871044) and [rephrase it](https://github.com/telerik/kendo-theme-default/commit/970f0bf108d7065aed42f9ac49fa3200529b6ed2), please verify if the bugfix is still in place.

/cc @theOrlin @inikolova 