### PR TITLE
fix(grid): Adjust filterable+sortable header margin for the sake of Edge

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -423,7 +423,6 @@
             }
         }
 
-
         .k-header > .k-link {
             margin: (-$cell-padding-y) (-$cell-padding-x);
             padding: $cell-padding-y $cell-padding-x;
@@ -432,6 +431,11 @@
             overflow: hidden;
             text-overflow: ellipsis;
         }
+
+        .k-header.k-filterable > .k-link {
+            margin-right: button-size();
+        }
+
         .k-header > .k-link:focus {
             text-decoration: none;
         }


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo-theme-default/issues/219