### PR TITLE
feat(grid): Add styles for opaque loading mask

### DIFF
--- a/scss/common/_base.scss
+++ b/scss/common/_base.scss
@@ -503,6 +503,12 @@
 
     .k-loading-mask {
         z-index: 100;
+
+        &.k-opaque {
+            .k-loading-color {
+                opacity: 1;
+            }
+        }
     }
     .k-loading-text {
         text-indent: -4000px;


### PR DESCRIPTION
Adds styles for opaque loading mask needed for infinite scroll feature.