### PR TITLE
fix(grid): fix header layout for locked columns

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -393,7 +393,7 @@
     div.k-grid-header,
     div.k-grid-footer {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
         align-items: stretch;
     }
 


### PR DESCRIPTION
Currently flex-direction: column breaks it in Angular:

![image](https://user-images.githubusercontent.com/90405/30032574-61f58e00-919f-11e7-98b6-8835266170cb.png)
