### PR TITLE
fix(grid): Restore missing filter row Autocomplete border

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -551,6 +551,10 @@
             .k-numerictextbox {
                 width: auto;
             }
+
+            .k-widget.k-autocomplete {
+                border-left-width: 1px;
+            }
         }
 
         .k-filtercell-operator {


### PR DESCRIPTION
Fixes missing left border of Autocomplete widget in filter row.