### PR TITLE
chore: reduce `.k-select` width of numeric

### DIFF
--- a/scss/common/_forms.scss
+++ b/scss/common/_forms.scss
@@ -178,7 +178,7 @@
             padding: 0;
             flex-direction: column;
             align-items: stretch;
-            width: button-inner-size();
+            width: add-three( $button-border-width, $icon-size, $button-padding-y * 2 );
         }
         .k-link {
             display: block;


### PR DESCRIPTION
Targets **Pickers issue related to bootstrap v4 update telerik/kendo-theme-bootstrap#314**, reduce `.k-select` width of numeric to reflect the rest of the pickers