### PR TITLE
chore: improve clear icon position

### DIFF
--- a/scss/common/_forms.scss
+++ b/scss/common/_forms.scss
@@ -28,7 +28,7 @@
             }
 
             .k-clear-value {
-                left: $padding-x;
+                left: $input-padding-x;
                 right: auto;
             }
         }
@@ -139,33 +139,38 @@
     .k-autocomplete,
     .k-dropdown-wrap,
     .k-multiselect {
+
         .k-clear-value,
         .k-i-loading {
             position: absolute;
-            top: 50%;
-            margin-top: -.5em;
+            right: $input-padding-x;
         }
 
         .k-clear-value {
-            right: $padding-x;
+            height: ($form-line-height * $font-size );
+            outline: 0;
+            opacity: .5;
+            cursor: pointer;
             display: none;
+            flex-direction: row;
+            align-items: center;
+            justify-content: center;
+            top: $input-padding-y;
         }
 
         .k-i-loading {
-            right: $padding-x-lg / 2;
+            top: 50%;
+            margin-top: -.5em;
         }
 
         &.k-state-focused,
         &.k-state-hover,
         &:hover {
             .k-clear-value {
-                display: inline-block;
-                outline: 0;
-                opacity: .5;
+                display: inline-flex;
 
                 &:hover {
                     opacity: 1;
-                    cursor: pointer;
                 }
             }
         }

--- a/scss/multiselect/_layout.scss
+++ b/scss/multiselect/_layout.scss
@@ -10,7 +10,7 @@
         }
 
         .k-clear-value {
-            top: $padding-x-lg / 2;
+            top: $input-padding-y;
             margin-top: 0;
         }
 


### PR DESCRIPTION
Targets **Multiselect issues related to bootstrap v4 update https://github.com/telerik/kendo-theme-bootstrap/issues/315**, clear input icon is not aligned