### PR TITLE
fix(datetimepicker): use box-sizing border-box for datetimepicker buttons

### DIFF
--- a/scss/datetime/_layout.scss
+++ b/scss/datetime/_layout.scss
@@ -87,6 +87,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            box-sizing: border-box;
         }
     }
 


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-theme-bootstrap/issues/318