### PR TITLE
chore(grid): Temporarily revert previous checkbox styling and behavior

### DIFF
--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -404,6 +404,16 @@
     }
 
     .k-grid {
+        input.k-checkbox {
+            margin-left: 1px;
+            margin-top: 3px;
+            width: 14px;
+            height: 15px;
+            z-index: 1;
+            clip: auto;
+            pointer-events: all;
+        }
+
         .k-checkbox-label {
             cursor: default;
         }


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo/issues/7619