### PR TITLE
fix(animation): remove zoom & push translation to support single element animation

### DIFF
--- a/scss/common/_animations.scss
+++ b/scss/common/_animations.scss
@@ -28,17 +28,12 @@
         }
 
         &-exit {
-            transform: translate(0, -100%);
+            transform: translate(0, 0);
         }
 
         &-exit-active {
-            transform: translate(100%, -100%);
+            transform: translate(100%, 0);
             transition: transform 300ms ease-in-out;
-        }
-
-        &-exit-active + &-exit-active,
-        &-enter-active + &-enter-active {
-            display: none;
         }
     }
 
@@ -55,17 +50,12 @@
         }
 
         &-exit {
-            transform: translate(0, -100%);
+            transform: translate(0, 0);
         }
 
         &-exit-active {
-            transform: translate(-100%, -100%);
+            transform: translate(-100%, 0);
             transition: transform 300ms ease-in-out;
-        }
-
-        &-exit-active + &-exit-active,
-        &-enter-active + &-enter-active {
-            display: none;
         }
     }
 
@@ -82,11 +72,11 @@
         }
 
         &-exit {
-            transform: translate(0, -100%);
+            transform: translate(0, 0);
         }
 
         &-exit-active {
-            transform: translate(0, 0);
+            transform: translate(0, 100%);
             transition: transform 300ms ease-in-out;
         }
     }
@@ -104,11 +94,11 @@
         }
 
         &-exit {
-            transform: translate(0, -100%);
+            transform: translate(0, 0);
         }
 
         &-exit-active {
-            transform: translate(0, -200%);
+            transform: translate(0, -100%);
             transition: transform 300ms ease-in-out;
         }
     }
@@ -148,44 +138,51 @@
         &-enter,
         &-appear {
             opacity: 0;
+            transform: scale(0);
         }
 
         &-enter-active,
         &-appear-active {
             opacity: 1;
-            transition: opacity 300ms ease-in-out;
+            transform: scale(1);
+            transition: transform, opacity 300ms ease-in-out;
         }
 
         &-exit {
-            transform: translate(0, -100%) scale(1);
+            opacity: 1;
+            transform: scale(1);
         }
 
         &-exit-active {
-            transform: translate(0, -100%) scale(0);
-            transition: transform 300ms ease-in-out;
+            opacity: 0;
+            transform: scale(2);
+            transition: transform, opacity 300ms ease-in-out;
         }
     }
 
     .k-zoom-out {
         &-enter,
         &-appear {
-            transform: scale(0);
+            opacity: 0;
+            transform: scale(2);
         }
 
         &-enter-active,
         &-appear-active {
+            transition: transform, opacity 300ms ease-in-out;
+            opacity: 1;
             transform: scale(1);
-            transition: transform 300ms ease-in-out;
         }
 
         &-exit {
             opacity: 1;
-            transform: translate(0, -100%);
+            transform: scale(1);
         }
 
         &-exit-active {
             opacity: 0;
-            transition: opacity 300ms ease-in-out;
+            transform: scale(0);
+            transition: transform, opacity 300ms ease-in-out;
         }
     }
 


### PR DESCRIPTION
When animating multiple child-containers the translation was needed to stack them together. This
prevented a single element to be animated in/out because the translation made it disapear outside
the parent-container instantly. In addition, some tweaks were added to zoom animations.