### PR TITLE
feat: add layout fixes file for IE9

### DIFF
--- a/scss/no-flexbox.scss
+++ b/scss/no-flexbox.scss
@@ -1,0 +1,70 @@
+.k-no-flexbox {
+    .k-calendar-infinite {
+        height: 330px;
+
+        .k-calendar-navigation,
+        .k-calendar-monthview {
+            height: 100%;
+            float: left;
+        }
+
+        .k-calendar-header {
+            display: block;
+
+            .k-today {
+                float: right;
+            }
+        }
+    }
+
+    .k-dateinput-wrap,
+    .k-dropdown-wrap,
+    .k-numeric-wrap,
+    .k-picker-wrap {
+        $k-select-width: 2em;
+        display: block;
+
+        .k-input {
+            width: calc(100% - #{$k-select-width});
+        }
+        .k-input,
+        .k-select {
+            display: inline-block;
+            vertical-align: middle;
+        }
+    }
+
+    .k-timepicker,
+    .k-datepicker {
+        display: inline-block;
+
+        .k-dateinput-wrap {
+            display: inline-block;
+        }
+
+        .k-select {
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+        }
+    }
+
+    .k-time-list-wrapper,
+    .k-time-separator {
+        display: inline-block;
+        vertical-align: middle;
+    }
+
+    .k-grid {
+        $grid-chrome-height: 37px !default;
+        .k-grid-container {
+            height: calc( 100% - #{$grid-chrome-height} );
+            display: block;
+        }
+
+        .k-grid-content {
+            height: 100%;
+        }
+    }
+}


### PR DESCRIPTION
Introduces the no-flexbox file, which should be manually included when building themes for IE9.

Usage (copied from Angular docs):

# Internet Explorer 9 Support

Component features that fully rely on the CSS flexbox module are not supported.

## Requirements

1. When the application is running in IE9, add the `k-no-flexbox` class to a container element:

    ```html
    <script>
      if (navigator.userAgent.indexOf("MSIE 9.0") > 0) {
        document.documentElement.className += " k-no-flexbox";
      }
    </script>
    ```

1. Compile a stylesheet that includes the flexbox layout fallback styles. IE9 has a limit of [4095 selectors per sheet](https://blogs.msdn.microsoft.com/ieinternals/2011/05/14/stylesheet-limits-in-internet-explorer/). If the stylesheet contains more rules, they will be dropped. This may mean splitting stylesheets into multiple parts, including only the components that you need.

    ```scss
    // import component files
    @import "~@progress/kendo-theme-default/scss/button";
    @import "~@progress/kendo-theme-default/scss/datetime";
    @import "~@progress/kendo-theme-default/scss/grid";

    // import layout fixes for browsers without flexbox support
    @import "~@progress/kendo-theme-default/scss/no-flexbox";
    ```