### PR TITLE
fix(grid): allow filter row components to shrink below min-width

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -577,6 +577,7 @@
 
         .k-filtercell-wrapper > .k-textbox {
             width: 100%;
+            min-width: 0;
         }
 
         .k-autocomplete .k-input,


### PR DESCRIPTION
required in firefox to allow elements to shrink below min-size
https://stackoverflow.com/questions/36247140/why-doesnt-flex-item-shrink-past-content-size#36247448

reported in telerik/kendo-angular#941