### PR TITLE
fix(icons): Add RTL styles for expand icon (telerik/kendo-ui-core#3360)

### DIFF
--- a/scss/common/_icons.scss
+++ b/scss/common/_icons.scss
@@ -705,6 +705,7 @@
     .k-rtl .k-i-indent-decrease {
         transform: scaleX(-1);
     }
+    .k-rtl .k-i-expand::before { content: "\e007"; }
 
     .k-sprite {
         display: inline-block;


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-ui-core/issues/3360