### PR TITLE
fix(animations): nested panelbar reveal

### DIFF
--- a/scss/common/_animations.scss
+++ b/scss/common/_animations.scss
@@ -336,12 +336,8 @@
             transition: max-height 300ms ease-in-out;
         }
 
-        &-exit {
-            max-height: 100%;
-        }
-
         &-exit-active {
-            max-height: 0;
+            max-height: 0 !important;
             transition: max-height 300ms ease-in-out;
         }
     }
@@ -357,12 +353,8 @@
             transition: max-width 300ms ease-in-out;
         }
 
-        &-exit {
-            max-width: 100%;
-        }
-
         &-exit-active {
-            max-width: 0;
+            max-width: 0 !important;
             transition: max-width 300ms ease-in-out;
         }
     }


### PR DESCRIPTION
`kendo-react-animations` Reveal animation now sets max-height/max-width to `none` when the animation has entered, to allow child elements to increase their hight/width without being limited by the parent. Whenever the animation will exit, max-height/max-width is being calculated and set dynamically in order to transition (from constant to 0), and when animation starts max-height/max-width property should override the previously set inline value. 
This is the reason behind using `!important`  