### PR TITLE
feat(calendar): styles for calendar year/decade/century views

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch": "webpack --watch",
     "embed-assets": "node build/embed-assets.js",
     "test": "npm run lint && npm run build && npm run api-check && npm run twbs-compat",
-    "twbs-compat": "webpack --env.twbs-compat",
+    "twbs-compat": "webpack --env.twbs-compat --bail",
     "semantic-release": "semantic-release pre && semantic-prerelease publish && semantic-release post"
   },
   "config": {

--- a/scss/calendar/_layout.scss
+++ b/scss/calendar/_layout.scss
@@ -7,6 +7,7 @@ $calendar-header-height: 2em;
 $calendar-weekdays-height: ( 29px / 14px ) * 1em;
 $calendar-navigation-item-height: 2em;
 $calendar-navigation-width: 5em;
+$calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigation-width + (2 * $calendar-cell-padding-y * 1em));
 
 @include exports('calendar/layout') {
 
@@ -224,7 +225,7 @@ $calendar-navigation-width: 5em;
                 @include hide-scrollbar('left');
             }
 
-            .k-calendar-monthview .k-content th {
+            .k-calendar-view .k-content th {
                 text-align: right;
             }
         }
@@ -248,6 +249,9 @@ $calendar-navigation-width: 5em;
 
         .k-title {
             font-weight: bold;
+            &:not(.k-state-disabled) {
+                cursor: pointer;
+            }
         }
 
         .k-today {
@@ -262,19 +266,19 @@ $calendar-navigation-width: 5em;
         }
     }
 
-    .k-calendar-monthview {
+    .k-calendar-view {
         display: flex;
         flex: 1 0 auto;
         flex-direction: column;
         overflow: hidden;
         margin: 0 $spacer-x;
+        width: $calendar-view-width;
 
         table {
             width: ($calendar-cell-size * 7);
         }
 
         .k-content {
-            height: 7 * $calendar-cell-size + $calendar-header-height;
             position: relative;
 
             > table {
@@ -310,6 +314,25 @@ $calendar-navigation-width: 5em;
             }
         }
 
+        &::after {
+            display: block;
+            position: absolute;
+            bottom: 0;
+            content: " ";
+            height: 0;
+            line-height: 0;
+            z-index: 1;
+            width: 150%;
+            left: -25%;
+            box-shadow: 0 0 $calendar-cell-size ($calendar-cell-size / 2) $bg-color;
+        }
+    }
+
+    .k-calendar-monthview {
+        .k-content {
+            height: 7 * $calendar-cell-size + $calendar-header-height;
+        }
+
         .k-calendar-weekdays {
             thead {
                 @include disabled;
@@ -325,18 +348,17 @@ $calendar-navigation-width: 5em;
                 line-height: $calendar-weekdays-height;
             }
         }
+    }
 
-        &::after {
-            display: block;
-            position: absolute;
-            bottom: 0;
-            content: " ";
-            height: 0;
-            line-height: 0;
-            z-index: 1;
-            width: 150%;
-            left: -25%;
-            box-shadow: 0 0 $calendar-cell-size ($calendar-cell-size / 2) $bg-color;
+    .k-calendar-yearview,
+    .k-calendar-decadeview,
+    .k-calendar-centuryview {
+        .k-content {
+            /*height: 7 * $calendar-cell-size + $calendar-header-height + $calendar-weekdays-height;*/
+            height: 20.715em; /* TODO: should be 290px like in monthview */
+            table {
+                table-layout: auto;
+            }
         }
     }
 

--- a/scss/calendar/_layout.scss
+++ b/scss/calendar/_layout.scss
@@ -349,8 +349,6 @@ $calendar-view-height: 7 * $calendar-cell-size + $calendar-header-height + $cale
         }
 
         .k-calendar-weekdays {
-            width: auto;
-
             thead {
                 @include disabled;
 
@@ -361,7 +359,6 @@ $calendar-view-height: 7 * $calendar-cell-size + $calendar-header-height + $cale
                 text-align: center;
                 border-width: 0;
                 padding: 0;
-                width: (($font-size * $calendar-cell-size) / $font-size-sm);
                 line-height: $calendar-weekdays-height;
             }
         }

--- a/scss/calendar/_layout.scss
+++ b/scss/calendar/_layout.scss
@@ -7,7 +7,8 @@ $calendar-header-height: 2em;
 $calendar-weekdays-height: ( 29px / 14px ) * 1em;
 $calendar-navigation-item-height: 2em;
 $calendar-navigation-width: 5em;
-$calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigation-width + (2 * $calendar-cell-padding-y * 1em));
+$calendar-view-width: 7 * $calendar-cell-size;
+$calendar-view-height: 7 * $calendar-cell-size + $calendar-header-height + $calendar-weekdays-height;
 
 @include exports('calendar/layout') {
 
@@ -273,11 +274,26 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
         flex: 1 0 auto;
         flex-direction: column;
         overflow: hidden;
-        margin: 0 $spacer-x;
-        //width: add-two(2 * $spacer-x, 7 * $calendar-cell-size);
+        padding: 0 $spacer-x;
+        // setting width / height prevents layout changes in meta views
+        width: $calendar-view-width;
+        height: $calendar-view-height;
+
+        .k-calendar-header {
+            flex: 0 0 auto;
+
+            // align fast navigation button with content
+            margin-left: -$button-padding-x;
+            padding-left: $button-padding-x;
+
+            .k-title {
+                margin-left: -$button-padding-x;
+            }
+        }
 
         .k-content {
             position: relative;
+            flex: 1 0 auto;
 
             > table {
                 position: relative;
@@ -355,8 +371,6 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
     .k-calendar-decadeview,
     .k-calendar-centuryview {
         .k-content {
-            //height: 7 * $calendar-cell-size + $calendar-header-height + $calendar-weekdays-height;
-            height: 20.715em; /* TODO: should be 290px like in monthview */
             table {
                 table-layout: auto;
             }
@@ -364,8 +378,8 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
             th {
                 font-size: inherit;
                 height: $calendar-header-height;
-                padding-left: $button-padding-x;
-                padding-right: $button-padding-x;
+                padding-left: 0;
+                padding-right: 0;
             }
 
             $cell-size: $calendar-view-width / 5;

--- a/scss/calendar/_layout.scss
+++ b/scss/calendar/_layout.scss
@@ -359,6 +359,10 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
             table {
                 table-layout: auto;
             }
+
+            .k-link {
+                width: auto;
+            }
         }
     }
 

--- a/scss/calendar/_layout.scss
+++ b/scss/calendar/_layout.scss
@@ -274,11 +274,7 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
         flex-direction: column;
         overflow: hidden;
         margin: 0 $spacer-x;
-        width: $calendar-view-width;
-
-        table {
-            width: ($calendar-cell-size * 7);
-        }
+        //width: add-two(2 * $spacer-x, 7 * $calendar-cell-size);
 
         .k-content {
             position: relative;
@@ -286,6 +282,7 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
             > table {
                 position: relative;
                 z-index: 1;
+                width: auto;
             }
 
             th {
@@ -336,17 +333,19 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
         }
 
         .k-calendar-weekdays {
+            width: auto;
+
             thead {
                 @include disabled;
 
                 font-weight: bold;
-                font-size: 10px;
             }
 
             th {
                 text-align: center;
                 border-width: 0;
                 padding: 0;
+                width: (($font-size * $calendar-cell-size) / $font-size-sm);
                 line-height: $calendar-weekdays-height;
             }
         }
@@ -365,19 +364,19 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
             th {
                 font-size: inherit;
                 height: $calendar-header-height;
-                padding-left: 0;
-                padding-right: 0;
+                padding-left: $button-padding-x;
+                padding-right: $button-padding-x;
             }
 
+            $cell-size: $calendar-view-width / 5;
             td {
-                $cell-size: $calendar-view-width / 5;
-                width: $cell-size;
-                height: $cell-size;
                 border-radius: $cell-size / 2;
             }
 
             .k-link {
-                width: auto;
+                width: $cell-size;
+                height: $cell-size;
+                line-height: $cell-size;
             }
         }
     }

--- a/scss/calendar/_layout.scss
+++ b/scss/calendar/_layout.scss
@@ -362,6 +362,13 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
                 table-layout: auto;
             }
 
+            th {
+                font-size: inherit;
+                height: $calendar-header-height;
+                padding-left: 0;
+                padding-right: 0;
+            }
+
             td {
                 $cell-size: $calendar-view-width / 5;
                 width: $cell-size;

--- a/scss/calendar/_layout.scss
+++ b/scss/calendar/_layout.scss
@@ -250,11 +250,6 @@ $calendar-view-height: 7 * $calendar-cell-size + $calendar-header-height + $cale
 
         .k-title {
             font-weight: bold;
-            cursor: pointer;
-
-            &:not(.k-state-disabled) {
-                opacity: 1;
-            }
         }
 
         .k-today {

--- a/scss/calendar/_layout.scss
+++ b/scss/calendar/_layout.scss
@@ -249,8 +249,10 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
 
         .k-title {
             font-weight: bold;
+            cursor: pointer;
+
             &:not(.k-state-disabled) {
-                cursor: pointer;
+                opacity: 1;
             }
         }
 
@@ -354,10 +356,17 @@ $calendar-view-width: 17em; //TODO: write it with calc(100% - ($calendar-navigat
     .k-calendar-decadeview,
     .k-calendar-centuryview {
         .k-content {
-            /*height: 7 * $calendar-cell-size + $calendar-header-height + $calendar-weekdays-height;*/
+            //height: 7 * $calendar-cell-size + $calendar-header-height + $calendar-weekdays-height;
             height: 20.715em; /* TODO: should be 290px like in monthview */
             table {
                 table-layout: auto;
+            }
+
+            td {
+                $cell-size: $calendar-view-width / 5;
+                width: $cell-size;
+                height: $cell-size;
+                border-radius: $cell-size / 2;
             }
 
             .k-link {

--- a/scss/calendar/_theme.scss
+++ b/scss/calendar/_theme.scss
@@ -91,11 +91,6 @@
             thead {
                 @include appearance( header );
             }
-
-            thead th,
-            .k-weekend .k-link {
-                opacity: $disabled-opacity;
-            }
         }
 
         .k-calendar-navigation {

--- a/scss/calendar/_theme.scss
+++ b/scss/calendar/_theme.scss
@@ -87,7 +87,7 @@
         }
 
         // Infinite calendar
-        .k-calendar-monthview {
+        .k-calendar-view {
             thead {
                 @include appearance( header );
             }


### PR DESCRIPTION
Styles for the new year/decade/century views of the Calendar.

The concrete implementation of the `fast navigation` feature can be found at https://github.com/telerik/kendo-angular-dateinputs/commits/calendar-fast-navigation