### PR TITLE
fix(grid): Add scrollbar to filter menu to avoid IE/Edge stretch bug …

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -801,6 +801,12 @@
     }
 }
 
+.k-ie,
+.k-edge {
+    .k-multicheck-wrap {
+        overflow-y: scroll;
+    }
+}
 
 @include exports( "filtermenu/layout" ) {
 


### PR DESCRIPTION
…(telerik/kendo-ui-core#2898)

Dealing with https://github.com/telerik/kendo-ui-core/issues/2898