### PR TITLE
fix(grid): Set grid header container display to block in IE

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -399,6 +399,10 @@
         align-items: stretch;
     }
 
+    .k-ie div.k-grid-header {
+        display: block;
+    }
+
     .k-grid-header {
         border-bottom-width: 1px;
 


### PR DESCRIPTION
Dealing with resizing problem in IE as described in https://github.com/telerik/kendo-theme-default/issues/745