### PR TITLE
Grid filter menu

### DIFF
--- a/scss/action-buttons/_theme.scss
+++ b/scss/action-buttons/_theme.scss
@@ -1,6 +1,7 @@
 @include exports('action-buttons/theme') {
 
     .k-action-buttons {
+        border-color: $popup-border;
 
         .k-button {
             color: inherit;
@@ -13,7 +14,7 @@
 
             &:focus,
             &.k-state-focused {
-                box-shadow: inset 0 0 0 2px rgba(0, 0, 0, .13);
+                box-shadow: $focused-shadow;
             }
 
             &:active,
@@ -33,7 +34,7 @@
 
                 &:focus,
                 &.k-state-focused {
-                    box-shadow: inset 0 0 0 2px rgba( 0, 0, 0, .13);
+                    box-shadow: $focused-shadow;
                 }
             }
 

--- a/scss/datetime/_layout.scss
+++ b/scss/datetime/_layout.scss
@@ -23,7 +23,8 @@
 
         .k-dateinput {
             width: 100%;
-            flex: 1;
+            flex: 1 1 0%;
+            margin: 0;
         }
 
         .k-dateinput-wrap {

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -803,10 +803,16 @@
 @include exports( "filtermenu/layout" ) {
 
     .k-filter-menu {
-        padding: $padding-y-sm;
+        $item-spacing: $spacer-y / 2;
+        $form-padding: $spacer-y;
+
+        > div {
+            padding: ($form-padding - $item-spacing) $form-padding;
+        }
 
         .k-button {
-            margin: ( $spacer-y / 2 ) 1% 0;
+            // BACKCOMPAT: remove when buttons div gets .k-action-buttons.k-button-group
+            margin: $item-spacing 1% 0;
             width: 48%;
             box-sizing: border-box;
             display: inline-block;
@@ -814,20 +820,26 @@
 
         .k-widget,
         .k-textbox {
-            margin: ( $spacer-y / 2 ) 0 0;
+            margin: $item-spacing 0;
             width: 100%;
             display: block;
         }
-        .k-textbox {
-            margin-bottom: 3px;
-        }
-
 
         .k-widget.k-filter-and {
             width: 6em;
-            margin: .5em 0;
+            margin: (2 * $item-spacing) 0;
+        }
+
+        .k-action-buttons {
+            margin: -$form-padding;
+            margin-top: $form-padding;
+
+            .k-button {
+                margin: 0; // <- BACKCOMPAT: remove when buttons div gets .k-action-buttons.k-button-group
+            }
         }
     }
+
     .k-multicheck-wrap {
         max-height: 300px;
         overflow: auto;

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -805,13 +805,14 @@
     .k-filter-menu {
         $item-spacing: $spacer-y / 2;
         $form-padding: $spacer-y;
-        $form-padding-y: $form-padding - $spacer-y;
+        $form-padding-y: $form-padding - $item-spacing;
 
-        > div {
+        > div:not(.k-animation-container), // BACKCOMPAT: remove when below class is added to container
+        .k-filter-menu-container {
             padding: $form-padding-y $form-padding;
         }
 
-        .k-button {
+        > div > div > .k-button {
             // BACKCOMPAT: remove when buttons div gets .k-action-buttons.k-button-group
             margin: $item-spacing 1% 0;
             width: 48%;
@@ -820,6 +821,7 @@
         }
 
         .k-widget,
+        .k-radio-list,
         .k-textbox {
             margin: $item-spacing 0;
             width: 100%;

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -805,9 +805,10 @@
     .k-filter-menu {
         $item-spacing: $spacer-y / 2;
         $form-padding: $spacer-y;
+        $form-padding-y: $form-padding - $spacer-y;
 
         > div {
-            padding: ($form-padding - $item-spacing) $form-padding;
+            padding: $form-padding-y $form-padding;
         }
 
         .k-button {
@@ -831,8 +832,7 @@
         }
 
         .k-action-buttons {
-            margin: -$form-padding;
-            margin-top: $form-padding;
+            margin: $form-padding (-$form-padding) (-$form-padding-y);
 
             .k-button {
                 margin: 0; // <- BACKCOMPAT: remove when buttons div gets .k-action-buttons.k-button-group

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -279,6 +279,13 @@
         transform: scale(1);
     }
 
+    // Check / Radio list
+    .k-radio-list {
+        .k-radio-label {
+            line-height: $checkbox-size * 1.25;
+        }
+    }
+
     .k-fieldset {
         margin: $fieldset-margin;
         border-width: 1px 0 0;

--- a/scss/multiselect/_layout.scss
+++ b/scss/multiselect/_layout.scss
@@ -29,6 +29,7 @@
                 }
 
                 .k-button {
+                    width: auto;
                     margin: $padding-y-sm $padding-y-sm 0 0;
 
                     .k-select {


### PR DESCRIPTION
| Before | After (no rendering changes) | After (with added classes) |
|-|-|-|
| ![image](https://user-images.githubusercontent.com/90405/31708064-ac30e220-b3f6-11e7-9a17-b14dff0344de.png) | ![image](https://user-images.githubusercontent.com/90405/31708147-dc2384c4-b3f6-11e7-8aa3-d29559033e40.png) | ![image](https://user-images.githubusercontent.com/90405/31708374-785334de-b3f7-11e7-917d-dae8ab273b28.png) |


To enable the rightmost styling:

1. add the `k-filter-menu-container` class to the nameless wrapper div inside the column menu
2. add the `k-action-buttons k-button-group` class to the nameless div that holds the buttons
3. flip the buttons to make the rendering the same as in the timepicker / spreadsheet

![image](https://user-images.githubusercontent.com/90405/31708584-15cdc59e-b3f8-11e7-94c0-dad04e1de3a7.png)


This PR also contains fixes for the datepicker and multiselect, visible when nested in the filter menu.

Do not squash.