### PR TITLE
chore: parallelize build

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "webpack --optimize-minimize --bail",
     "watch": "webpack --watch",
     "embed-assets": "node build/embed-assets.js",
-    "test": "npm run lint && npm run build && npm run api-check && npm run twbs-compat",
+    "test": "npm-run-all --parallel lint build api-check twbs-compat",
     "twbs-compat": "webpack --env.twbs-compat --bail",
     "semantic-release": "semantic-release pre && semantic-prerelease publish && semantic-release post"
   },
@@ -75,6 +75,7 @@
     "glob": "^7.0.5",
     "handlebars": "^4.0.10",
     "mime": "^1.3.4",
+    "npm-run-all": "^4.1.1",
     "sass-lint": "^1.7.0",
     "sassdoc": "^2.1.20",
     "semantic-release": "^6.3.6",


### PR DESCRIPTION
makes the local build twice as fast.

before: npm test  42.81s user 2.55s system 104% cpu **43.516 total**
after:  npm test  41.84s user 2.66s system 209% cpu **21.196 total**