### PR TITLE
Angular invalid state

### DIFF
--- a/scss/common/_forms.scss
+++ b/scss/common/_forms.scss
@@ -259,6 +259,7 @@
 
     .ng-invalid.ng-touched,
     .ng-invalid.ng-dirty {
+        &.k-autocomplete,
         &.k-maskedtextbox > .k-textbox {
             color: $error;
             border-color: $invalid-border;

--- a/scss/common/_forms.scss
+++ b/scss/common/_forms.scss
@@ -256,12 +256,18 @@
         right: 3px;
     }
 
-    .k-widget.ng-invalid.ng-touched,
-    .k-widget.ng-invalid.ng-dirty {
-        .k-dateinput-wrap,
-        .k-dropdown-wrap,
-        .k-numeric-wrap,
-        .k-picker-wrap {
+
+    .ng-invalid.ng-touched,
+    .ng-invalid.ng-dirty {
+        &.k-maskedtextbox > .k-textbox {
+            color: $error;
+            border-color: $invalid-border;
+        }
+
+        .k-dateinput-wrap, // dateinput is nested deeper in datepicker
+        > .k-dropdown-wrap,
+        > .k-numeric-wrap,
+        > .k-picker-wrap {
             color: $error;
             border-color: $invalid-border;
 


### PR DESCRIPTION
Adds an invalid state to the multiselect and autocomplete components, after the report in telerik/kendo-angular#997

Do not squash.