### PR TITLE
fix(grid): remove double border for browsers without scrollbar

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -760,6 +760,9 @@
         overflow: hidden;
     }
 
+    &.k-grid-no-scrollbar .k-grid-header-wrap {
+        border-width: 0;
+    }
 }
 
 // PDF export


### PR DESCRIPTION
see telerik/kendo-angular-grid#380