### PR TITLE
fix(grid): Improve Grid popup editor checkbox alignment

### DIFF
--- a/scss/edit-form/_layout.scss
+++ b/scss/edit-form/_layout.scss
@@ -93,7 +93,7 @@
         }
 
         .k-checkbox-label {
-            margin-top: $input-padding-y;
+            margin-top: add-two($input-padding-y, $input-border-width);
         }
 
         .k-reset > li + li {


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo/issues/7695