### PR TITLE
chore: remove unused styles

### DIFF
--- a/scss/common/_base.scss
+++ b/scss/common/_base.scss
@@ -315,20 +315,6 @@
         }
     }
 
-
-    // Error-state
-    .k-state-error {
-        border-style: ridge;
-    }
-
-
-    // TODO: what is smpty state?
-    // Empty state
-    .k-state-empty {
-        font-style: italic;
-    }
-
-
     // Dirty indicator
     .k-dirty {
         border-color: $error $error transparent transparent;

--- a/scss/input/_layout.scss
+++ b/scss/input/_layout.scss
@@ -121,8 +121,6 @@
         }
 
         &.k-state-empty {
-            font-style: normal;
-
             > .k-label {
                 transform: translate( 0, 0 ) scale( 1 );
             }


### PR DESCRIPTION
`k-state-error` needs to be renamed to `k-state-invalid` (used only in the jQuery colorpicker, does not appear to be in demos)
`k-state-empty` is only used in input/_layout, where it is overwritten