### PR TITLE
fix(grid): Remove extra margin in header title in Firefox

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -438,6 +438,11 @@
             display: block;
             overflow: hidden;
             text-overflow: ellipsis;
+
+            .k-ff & {
+                margin-inline-start: 0;
+                padding-inline-start: 0;
+            }
         }
 
         .k-header.k-filterable > .k-link {


### PR DESCRIPTION
Partly dealing with https://github.com/telerik/kendo-theme-default/issues/617