### PR TITLE
fix(numerictextbox): remove invalid input border in Firefox

### DIFF
--- a/scss/numerictextbox/_layout.scss
+++ b/scss/numerictextbox/_layout.scss
@@ -21,6 +21,10 @@
 
         > .k-input {
             flex: 1 1 0;
+
+            &:invalid {
+                box-shadow: none;
+            }
         }
     }
 }


### PR DESCRIPTION
Partially fixing https://github.com/telerik/kendo-theme-default/issues/617