### PR TITLE
fix(multiselect): improve height of token with empty string

### DIFF
--- a/scss/multiselect/_layout.scss
+++ b/scss/multiselect/_layout.scss
@@ -62,6 +62,7 @@
 
         // Token
         .k-button {
+            min-height: calc(#{$form-line-height}*1em + #{$button-padding-y-sm} + 2px);
             padding: ($button-padding-y-sm / 2) ($button-padding-x / 2);
             margin: $padding-y-sm 0 0 $padding-y-sm;
             cursor: default;


### PR DESCRIPTION
related https://github.com/telerik/kendo-ui-core/issues/3723