### PR TITLE
[DELETED] fix(icons): use right angle icons for collapse

### DIFF
--- a/scss/common/_icons.scss
+++ b/scss/common/_icons.scss
@@ -616,7 +616,7 @@
     .k-i-sarrow-e::before { @extend .k-i-arrow-60-right; }
     .k-i-sarrow-s::before { @extend .k-i-arrow-60-down; }
     .k-i-sarrow-w::before { @extend .k-i-arrow-60-left; }
-    .k-i-collapse::before { @extend .k-i-arrow-60-down; }
+    .k-i-collapse::before { @extend .k-i-collapse-se; }
     .k-i-expand::before { @extend .k-i-arrow-60-right; }
     .k-i-expand-n::before { @extend .k-i-arrow-60-up; }
     .k-i-expand-e::before { @extend .k-i-arrow-60-right; }


### PR DESCRIPTION
Targets https://github.com/telerik/kendo/issues/7794#issuecomment-339983367.

Discussed with @lkarakoleva.