### PR TITLE
fixes/ie-11-dialog-window-height

### DIFF
--- a/scss/dialog/_layout.scss
+++ b/scss/dialog/_layout.scss
@@ -4,6 +4,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        flex-direction: column;
         position: fixed;
         top: 0;
         left: 0;


### PR DESCRIPTION
- adds height to the `k-window` wrapping class which resolves an issue with IE11 not properly setting the height of the dialog when the text exceeds the display