### PR TITLE
fix(ripple): contain ripple in its target element

### DIFF
--- a/scss/ripple/_layout.scss
+++ b/scss/ripple/_layout.scss
@@ -1,4 +1,7 @@
 @include exports( 'ripple/layout' ) {
+    .k-ripple-target {
+        position: relative;
+    }
 
     .k-ripple {
         position: absolute;


### PR DESCRIPTION
The element that contains the ripple needs a positioning to prevent it from leaking out. The class is added by the ripple code.