### PR TITLE
fix(grid): add reorder styles for ng grid

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -308,6 +308,23 @@
         border-color: inherit;
         line-height: button-size();
     }
+
+    .k-grouping-header-flex {
+        display: flex;
+        flex-shrink: 0;
+        padding: 0;
+
+        > .k-indicator-container {
+            display: inline-flex;
+            margin: 0;
+            padding: $padding-y 0 $padding-y $padding-x;
+
+            &:last-child {
+                flex-grow: 1;
+            }
+        }
+    }
+
     .k-group-indicator,
     .k-drag-clue {
         @include border-radius();

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -51,6 +51,16 @@
         font-weight: bold;
     }
 
+    .k-grouping-dropclue {
+        &::before {
+            border-color: $grid-chrome-text transparent transparent;
+        }
+
+        &::after {
+            background-color: $grid-chrome-text;
+        }
+    }
+
     .k-grid {
         background-clip: padding-box;
 
@@ -88,16 +98,6 @@
             .k-icon {
                 color: $grid-chrome-text;
                 text-decoration: none;
-            }
-        }
-
-        .k-grouping-dropclue {
-            &::before {
-                border-color: $grid-chrome-text transparent transparent;
-            }
-
-            &::after {
-                background-color: $grid-chrome-text;
             }
         }
 


### PR DESCRIPTION
The Angular grid uses flexbox for its header styles to simplify calculations and alignment. It also attaches the `k-grouping-dropclue` to the `<body>`, not inside the grid.