### PR TITLE
fix(grid): headers border color

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -32,6 +32,7 @@
         }
 
         .k-grid-aria-root {
+            border-color: inherit;
             display: flex;
             flex-direction: column;
             overflow: hidden;


### PR DESCRIPTION
Border color is reset due to additional 'k-grid-aria-root' element, https://plnkr.co/edit/N9VcY8yjejXkngFTGxJd?p=preview