### PR TITLE
fix(chart): remove spacing from tooltip

### DIFF
--- a/scss/dataviz/_layout.scss
+++ b/scss/dataviz/_layout.scss
@@ -53,6 +53,10 @@ $chart-title-font-size: 1.143em !default;
         transition: left ease-in 80ms, top ease-in 80ms;
     }
 
+    .k-chart-tooltip-wrapper > .k-popup {
+        padding: 0;
+    }
+
     .k-chart-tooltip table {
         border-spacing: 0;
         border-collapse: collapse;


### PR DESCRIPTION
solves issues when the popup padding is set (in bootstrap and material)

see https://github.com/telerik/kendo-angular/issues/1247