### PR TITLE
Improve splitter styles

### DIFF
--- a/scss/splitter/_layout.scss
+++ b/scss/splitter/_layout.scss
@@ -54,18 +54,12 @@
         .k-icon {
             font-size: $splitter-resize-icon-size;
             display: block;
+            cursor: pointer;
         }
     }
 
     .k-splitbar-draggable-horizontal { cursor: col-resize; }
     .k-splitbar-draggable-vertical { cursor: row-resize; }
-
-    .k-collapse-next,
-    .k-collapse-prev,
-    .k-expand-next,
-    .k-expand-prev {
-        cursor: pointer;
-    }
 
     .k-ghost-splitbar-horizontal,
     .k-splitbar-horizontal {

--- a/scss/splitter/_layout.scss
+++ b/scss/splitter/_layout.scss
@@ -93,7 +93,7 @@
         height: $splitter-drag-handle-length;
     }
 
-    .k-splitter .k-resize-handle {
+    .k-splitbar .k-resize-handle {
         display: none;
         background-color: currentColor;
     }


### PR DESCRIPTION
Add fix for telerik/kendo-theme-default#861, reuse icon selector