### PR TITLE
fix(sparkline): remove border and padding from tooltip

### DIFF
--- a/scss/dataviz/_layout.scss
+++ b/scss/dataviz/_layout.scss
@@ -53,8 +53,10 @@ $chart-title-font-size: 1.143em !default;
         transition: left ease-in 80ms, top ease-in 80ms;
     }
 
+    .k-sparkline-tooltip-wrapper > .k-popup,
     .k-chart-tooltip-wrapper > .k-popup {
         padding: 0;
+        border-width: 0;
     }
 
     .k-chart-tooltip table {


### PR DESCRIPTION
sequel of telerik/kendo-angular#1247